### PR TITLE
BASW-42: Adding new hook to allow using any payment processor as paylater processor

### DIFF
--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -898,4 +898,32 @@ abstract class wf_crm_webform_base {
     return CRM_Core_Key::get('CRM_Contribute_Controller_Contribution', TRUE);
   }
 
+  /**
+   * Determines if the target payment processor
+   * is pay later payment processor or not.
+   *
+   * @param int $paymentProcessorsID
+   *   The target payment processor ID
+   *
+   * @return bool
+   *   TRUE if the target payment processor is
+   *   pay later or if no payment processor is
+   *   selected, Return FALSE otherwise.
+   */
+  protected function isPayLaterPaymentProcessor($paymentProcessorsID) {
+    $payLaterPaymentProcessors = array();
+    drupal_alter('webform_civicrm_paylater_payment_processors', $payLaterPaymentProcessors);
+
+    $isPayLaterPaymentProcessor = FALSE;
+
+    if (
+      in_array($paymentProcessorsID, $payLaterPaymentProcessors) ||
+      empty($paymentProcessorsID)
+    ) {
+      $isPayLaterPaymentProcessor = TRUE;
+    }
+
+    return $isPayLaterPaymentProcessor;
+  }
+
 }

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1470,7 +1470,9 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $fid = 'civicrm_1_contribution_1_contribution_total_amount';
     $contributionParams = $this->contributionParams();
     $frequencyUnit = wf_crm_aval($contributionParams, 'frequency_unit');
-    $contributionIsPayLater = empty($this->data['contribution'][1]['contribution'][1]['payment_processor_id']);
+
+    $contributionIsPayLater = $this->isPayLaterPaymentProcessorSubmitted();
+
     $numInstallments = $this->getData('civicrm_1_contribution_1_contribution_installments');
     $numContributions = 1;
     $date = (new DateTime())->format('Y-m-d');
@@ -1548,6 +1550,24 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
   }
 
   /**
+   * Determines if the submitted payment processor
+   * is pay later payment processor or not.
+   *
+   * @return bool
+   *   TRUE if the submitted payment processor is
+   *   pay later or if no payment processor is
+   *   selected, Return FALSE otherwise.
+   */
+  private function isPayLaterPaymentProcessorSubmitted() {
+    $paymentProcessorID = NULL;
+    if (!empty($this->data['contribution'][1]['contribution'][1]['payment_processor_id'])) {
+      $paymentProcessorID = $this->data['contribution'][1]['contribution'][1]['payment_processor_id'];
+    }
+
+    return $this->isPayLaterPaymentProcessor($paymentProcessorID);
+  }
+
+  /**
    * Returns date calculated according to given contribution number
    * and frequency unit relatively to specified $fromDate date.
    *
@@ -1617,7 +1637,10 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
    * @return bool
    */
   private function isLivePaymentProcessor() {
-    if ($this->payment_processor) {
+    $payLaterPaymentProcessors = array();
+    drupal_alter('webform_civicrm_paylater_payment_processors', $payLaterPaymentProcessors);
+
+    if ($this->payment_processor && !in_array($this->payment_processor['id'], $payLaterPaymentProcessors)) {
       if ($this->payment_processor['billing_mode'] == self::BILLING_MODE_LIVE) {
         return TRUE;
       }
@@ -1877,7 +1900,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
    */
   private function createDeferredPayment() {
     $this->contributionIsIncomplete = TRUE;
-    $this->contributionIsPayLater = empty($this->data['contribution'][1]['contribution'][1]['payment_processor_id']);
+    $this->contributionIsPayLater = $this->isPayLaterPaymentProcessorSubmitted();
     $params = $this->contributionParams();
     $params['contribution_status_id'] = 'Pending';
     $params['is_pay_later'] = $this->contributionIsPayLater;
@@ -1885,7 +1908,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
 
     //Fix IPN payments marked as paid by cheque
     if (empty($params['payment_instrument_id'])) {
-      if (!empty($params['payment_processor_id']) && $this->contribution_page['is_monetary']) {
+      if (!$this->contributionIsPayLater && $this->contribution_page['is_monetary']) {
         $defaultPaymentInstrument = CRM_Core_OptionGroup::values('payment_instrument', FALSE, FALSE, FALSE, 'AND is_default = 1');
         $params['payment_instrument_id'] = key($defaultPaymentInstrument);
       }

--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -214,6 +214,8 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
       else {
         $js_vars['paymentProcessor'] = $this->getData($fid);
       }
+
+      $js_vars['payLaterPaymentProcessor'] = $this->isPayLaterPaymentProcessor($js_vars['paymentProcessor']);
     }
     if ($js_vars) {
       $this->form['#attached']['js'][] = array(

--- a/js/webform_civicrm_payment.js
+++ b/js/webform_civicrm_payment.js
@@ -14,9 +14,8 @@ cj(function($) {
   }
 
   function loadBillingBlock() {
-    var type = getPaymentProcessor();
-    if (type && type != '0') {
-      $('#billing-payment-block').load(setting.contributionCallback + '&' + setting.processor_id_key + '=' + type, function() {
+    if (!setting.payLaterPaymentProcessor) {
+      $('#billing-payment-block').load(setting.contributionCallback + '&' + setting.processor_id_key + '=' + getPaymentProcessor(), function() {
         $('#billing-payment-block').trigger('crmLoad').trigger('crmFormLoad');
         if (setting.billingSubmission) {
           $.each(setting.billingSubmission, function(key, val) {


### PR DESCRIPTION
A new hook is added : 

**hook_webform_civicrm_paylater_payment_processors_alter**

that allow other modules to hook into this module and define any CiviCRM payment processor to behave as a paylater payment processor, which means that it will not ask you to enter credit card details when submitting a civicrm webform where contributions creation is enabled  and the payment processor is set to any of the processors defined in the hook..

Example : 

Suppose we have a payment processor  in civicrm called **test processor**, By default this is how setting the contribution to use "pay later"  will behave :

![paylater](https://user-images.githubusercontent.com/6275540/36336644-a4d4bd18-1381-11e8-91ac-49b91366bc5b.gif)

And this is how setting the the contribution to use "test processor"  will behave :

![before_hook](https://user-images.githubusercontent.com/6275540/36336663-bc0f04f2-1381-11e8-891c-2ca513bbcd84.gif)


But if we want "test processor" to behave similar to "pay later"  then we need to create a new module, let's call it  **test_mod** and we need to implement this hooks in its **test_mod.module** file  like this : 

```php
/**
 * Implements hook_webform_civicrm_paylater_payment_processors_alter
*
 * @param $payLaterPaymentProcessors
 */
function test_mod_webform_civicrm_paylater_payment_processors_alter(&$payLaterPaymentProcessors) {
  $testPaymentProcessor= civicrm_api3('PaymentProcessor', 'get', array(
    'sequential' => 1,
    'name' => "test processor",
  ));

  if (!empty($testPaymentProcessor['values'])) {
      $payLaterPaymentProcessors[] = $testPaymentProcessor['values'][0]['id'];
  }
}
```

So after enabling the module and clearing the cache, and as we can now see below, it behave similar to "pay later": 

![after_hook](https://user-images.githubusercontent.com/6275540/36336735-5f3ccf42-1382-11e8-863a-7fded0d5654b.gif)

