### PR TITLE
BASW-336: Update Options And Help Label Text

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -77,8 +77,11 @@ function wf_crm_field_options($field, $context, $data) {
     elseif ($table == 'membership' && $name == 'num_terms') {
       $ret = drupal_map_assoc(range(1, 9));
     }
-    elseif ($table == 'membership' && in_array($name, array('start_date_rules', 'end_date_rules'))) {
-      $ret = array(0 => t('Automatic'), 1 => t('User Select'), 2 => t('Relative to active membership end date'));
+    elseif ($table == 'membership' && $name == 'start_date_rules') {
+      $ret = array(0 => t('Automatic'), 1 => t('Selected date'), 2 => t('After the end date of selected membership(s)'));
+    }
+    elseif ($table == 'membership' && $name == 'end_date_rules') {
+      $ret = array(0 => t('Automatic'), 1 => t('Selected date'), 2 => t('Match the end date of selected membership(s)'));
     }
     // Aside from the above special cases, most lists can be fetched from api.getoptions
     else {

--- a/includes/wf_crm_admin_help.inc
+++ b/includes/wf_crm_admin_help.inc
@@ -304,21 +304,20 @@ class wf_crm_admin_help {
   
   public static function membership_start_date_rules() {
     print '<p>'.
-      t('\'Automatic\' indicates that the start date will follow normal CiviCRM rules. i.e. New memberships will start immediately from date of sign-up and renewals will extend memberships.').
-      '</p><br /><p>'.
-      t('\'User select\' will create a new webform date component that the administrator can configure in many ways including adding a fixed or relative start or end date.').'</p>'.
-      '</p><br /><p>'.
-      t('\'Relative to active membership end date\' will modify the start date of the new membership as follows:
-        <p>It will first check whether the user has an existing membership of this type. If so it will follow the automatic membership rules.</p>
-        <p>If the user does not have a membership of this type, it will create a new membership and then check if the user has any active memberships of the relevant types specified. If not then the system will follow automatic membership rules.</p>
-        <p>If so it will set the start date of the new membership to be the day following the end date of the existing active membership.</p>
-        <p>If the user currently has multiple relevant membership types the start date will be one day following the end date of the membership with the latest end date.</p>');
+      t('Select "Automatic" to create/ renew membership following default calculation.').
+      '</p><p>'.
+      t('Select "Selected date" to add a start date field to the form.').'</p>'.
+      '</p><p>'.
+      t('Select "After the end date of selected membership(s)" to start the new membership term after an active membership of the selected types').'</p>';
   }
   
   public static function membership_end_date_rules() {
     print '<p>'.
-      t('"Automatic" indicates that new membership end date will be calculated according to the start date and the membership duration').
-      '</p>';
+      t('Select "Automatic" to create/ renew membership following default calculation.').
+      '</p><p>'.
+      t('Select "Selected date" to add a end date field to the form.').'</p>'.
+      '</p><p>'.
+      t('Select "Match the end date of selected membership(s)" to match the end date of the new membership term with the end date of an active membership of the selected types').'</p>';
   }
   
   public static function membership_pro_rate_membership() {


### PR DESCRIPTION
Overview
----------------------------------------
"Start date calculation" containing the following options:

Automatic -
Selected date
After the end date of selected membership(s)
Adding a help text for "Start date calculation": 
'Select - Automatic - to create/ renew membership following default calculation. \n Select "Selected date" to add a start date field to the form. \n Select "After the end date of selected membership(s)" to start the new membership term after an active membership of the selected types'.
"End date calculation" containing the following options:

Automatic -
Selected date
Match the end date of selected membership(s)
Adding a help text for "End date calculation": 
'Select - Automatic - to create/ renew membership following default calculation. \n Select "Selected date" to add a start date field to the form. \n Select "Match the end date of selected membership(s)" to match the end date of the new membership term with the end date of an active membership of the selected types'.