### PR TITLE
BASW-126: Membership start date rules

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -77,6 +77,9 @@ function wf_crm_field_options($field, $context, $data) {
     elseif ($table == 'membership' && $name == 'num_terms') {
       $ret = drupal_map_assoc(range(1, 9));
     }
+    elseif ($table == 'membership' && $name == 'start_date_rules') {
+      $ret = array(0 => t('Automatic'), 1 => t('User Select'), 2 => t('Relative to active membership end date'));
+    }
     // Aside from the above special cases, most lists can be fetched from api.getoptions
     else {
       $params = array('field' => $name, 'context' => 'create');
@@ -95,6 +98,10 @@ function wf_crm_field_options($field, $context, $data) {
       else {
         // Pass data into api.getoptions for contextual filtering
         $params += wf_crm_aval($data, "$ent:$c:$table:$n", array());
+        // We need the same options as membership_type_id for start_date_memberships
+        if($params['field'] == 'start_date_memberships') {
+          $params['field'] = 'membership_type_id';
+        }
       }
       $ret = wf_crm_apivalues($table, 'getoptions', $params);
 
@@ -1178,6 +1185,20 @@ function wf_crm_get_fields($var = 'fields') {
         'expose_list' => TRUE,
         'value' => 1,
         'empty_option' => t('Enter Dates Manually'),
+      );
+      // Membership Date Rule Fields
+      $fields['membership_start_date_rules'] = array(
+        'name' => t('Start Date'),
+        'type' => 'select',
+        'expose_list' => TRUE,
+        'value' => 0,
+        'exposed_empty_option' => t('Automatic'),
+      );
+      $fields['membership_start_date_memberships'] = array (
+        'name' => t('Select Membership Types'),
+        'type' => 'select',
+        'expose_list' => TRUE,
+        'extra' => array('multiple' => 1),
       );
       if (isset($sets['contribution'])) {
         $fields['membership_fee_amount'] = array(

--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -78,7 +78,7 @@ function wf_crm_field_options($field, $context, $data) {
       $ret = drupal_map_assoc(range(1, 9));
     }
     elseif ($table == 'membership' && $name == 'start_date_rules') {
-      $ret = array(0 => t('Automatic'), 1 => t('User Select'), 2 => t('Relative to active membership end date'));
+      $ret = array(0 => '- ' . t('Automatic') . ' -', 1 => '- ' . t('User Select') . ' -', 2 => t('Relative to active membership end date'));
     }
     // Aside from the above special cases, most lists can be fetched from api.getoptions
     else {
@@ -1192,7 +1192,7 @@ function wf_crm_get_fields($var = 'fields') {
         'type' => 'select',
         'expose_list' => TRUE,
         'value' => 0,
-        'exposed_empty_option' => t('Automatic'),
+        'exposed_empty_option' => '- ' . t('Automatic') . ' -',
       );
       $fields['membership_start_date_memberships'] = array (
         'name' => t('Select Membership Types'),

--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -1309,6 +1309,12 @@ class wf_crm_admin_form {
       if ($field['type'] != 'hidden') {
         $options += array('create_civicrm_webform_element' => t('- User Select -'));
       }
+      // Remove 'create_civicrm_webform_element' option for membership date rules
+      if (strpos($field['form_key'], '_start_date_rules') !== FALSE
+          || 
+          strpos($field['form_key'], '_start_date_memberships') !== FALSE) {
+           unset($options['create_civicrm_webform_element']);
+      }
       $options += wf_crm_field_options($field, 'config_form', $this->data);
       $item += array(
         '#type' => 'select',

--- a/includes/wf_crm_admin_help.inc
+++ b/includes/wf_crm_admin_help.inc
@@ -308,6 +308,18 @@ class wf_crm_admin_help {
       '</p>';
   }
 
+  public static function membership_start_date_rules() {
+    print '<p>'.
+      t('\'Automatic\' indicates that the start date will follow normal CiviCRM rules. i.e. New memberships will start immediately from date of sign-up and renewals will extend memberships.').
+      '</p><br /><p>'.
+      t('User select will create a new webform date component that the administrator can configure in many ways including adding a fixed or relative start or end date.').'</p>'.
+      '</p><br /><p>'.
+      t('\'Relative to active membership end date\' will modify the start date of the new membership as follows:
+        <p>It will first check whether the user has an existing membership of this type. If so it will follow the automatic membership rules.</p>
+        <p>If the user does not have a membership of this type, it will create a new membership and then check if the user has any active memberships of the relevant types specified. If not then the system will follow automatic membership rules.</p>
+        <p>If so it will set the start date of the new membership to be the day following the end date of the existing active membership.</p>
+        <p>If the user currently has multiple relevant membership types the start date will be one day following the end date of the membership with the latest end date.</p>');
+  }
   public static function membership_fee_amount() {
     print '<p>' .
       t('Price for this membership per term. If this field is enabled, the default minimum membership fee from CiviCRM membership type settings will not be loaded.') .

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1187,6 +1187,11 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       // The api won't let us manually set status without this weird param
       $params['skipStatusCal'] = !empty($params['status_id']);
 
+      // Process date rules only for new memberships
+      if (!isset($params['id'])) {
+        $params = $this->processMembershipDateRules($cid, $params);
+      }
+
       $result = wf_civicrm_api('membership', 'create', $params);
 
       if (!empty($result['id'])) {
@@ -1212,6 +1217,35 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         }
       }
     }
+  }
+
+  /**
+   * Process membership date rules
+   */
+  private function processMembershipDateRules($cid, $params) {
+    if (!empty($params['start_date_rules']) && $params['start_date_rules'] == 2) {
+      // fetch existing membership having latest end_date
+      $membershipParams = array (
+        'sequential' => 1,
+        'active_only' => 1,
+        'contact_id' => $cid,
+        'options' => array ('sort' => "end_date DESC", 'limit' => 1),
+      );
+      // Handle case when memberships are selected for start date rules
+      if (!empty($params['start_date_memberships'])) {
+        $membershipParams['membership_type_id'] = array (
+          'IN' => $params['start_date_memberships']
+        );
+      }
+
+      $activeMemberships = civicrm_api3('Membership', 'get', $membershipParams);
+      if ($activeMemberships['count']) {
+        $activeMembershipsEndDate = new DateTime($activeMemberships['values'][0]['end_date']);
+        $start_date = $activeMembershipsEndDate->modify('+1 day');
+        $params['start_date'] = $start_date->format('Ymd');
+      }
+    }
+    return $params;
   }
 
   /**

--- a/js/webform_civicrm_admin.js
+++ b/js/webform_civicrm_admin.js
@@ -512,7 +512,16 @@ var wfCiviAdmin = (function ($, D) {
           $target.show();
         }
       }).change();
-
+      $('select[name$=_membership_start_date_rules]', context).change(function(e, type) {
+        var $dateRuleMembershipField = $(this).parent().siblings('[class$="-start-date-memberships"]');
+        var $relativeToExistingMembership = 2;
+        if ($(this).val() == $relativeToExistingMembership) {
+          $dateRuleMembershipField.show();
+        }
+        else {
+          $dateRuleMembershipField.hide();
+        }
+      }).trigger('change', 'init');
       function billingMessages() {
         var $pageSelect = $('[name=civicrm_1_contribution_1_contribution_contribution_page_id]');
         // Warning about contribution page with no email


### PR DESCRIPTION
**Overview:**
In Webform/CiviCRM it is not possible to specify the start date of a new membership comparatively to an existing membership. It is not possible to delay the start of the new membership to the end of an existing membership of a different type.

This PR adds start date rules fields and behaviour which allows administrators to choose relative start dates.