### PR TITLE
BASW-131: Membership end date rules

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -77,7 +77,7 @@ function wf_crm_field_options($field, $context, $data) {
     elseif ($table == 'membership' && $name == 'num_terms') {
       $ret = drupal_map_assoc(range(1, 9));
     }
-    elseif ($table == 'membership' && $name == 'start_date_rules') {
+    elseif ($table == 'membership' && in_array($name, array('start_date_rules', 'end_date_rules'))) {
       $ret = array(0 => '- ' . t('Automatic') . ' -', 1 => '- ' . t('User Select') . ' -', 2 => t('Relative to active membership end date'));
     }
     // Aside from the above special cases, most lists can be fetched from api.getoptions
@@ -99,7 +99,7 @@ function wf_crm_field_options($field, $context, $data) {
         // Pass data into api.getoptions for contextual filtering
         $params += wf_crm_aval($data, "$ent:$c:$table:$n", array());
         // We need the same options as membership_type_id for start_date_memberships
-        if($params['field'] == 'start_date_memberships') {
+        if (in_array($params['field'], array('start_date_memberships', 'end_date_memberships'))) {
           $params['field'] = 'membership_type_id';
         }
       }
@@ -1186,20 +1186,7 @@ function wf_crm_get_fields($var = 'fields') {
         'value' => 1,
         'empty_option' => t('Enter Dates Manually'),
       );
-      // Membership Date Rule Fields
-      $fields['membership_start_date_rules'] = array(
-        'name' => t('Start Date'),
-        'type' => 'select',
-        'expose_list' => TRUE,
-        'value' => 0,
-        'exposed_empty_option' => '- ' . t('Automatic') . ' -',
-      );
-      $fields['membership_start_date_memberships'] = array (
-        'name' => t('Select Membership Types'),
-        'type' => 'select',
-        'expose_list' => TRUE,
-        'extra' => array('multiple' => 1),
-      );
+
       if (isset($sets['contribution'])) {
         $fields['membership_fee_amount'] = array(
           'name' => t('Membership Fee'),
@@ -1242,6 +1229,37 @@ function wf_crm_get_fields($var = 'fields') {
           'empty_option' => t('None'),
         );
       }
+      // Membership Date Rule Fields
+      $fields['membership_start_date_rules'] = array(
+        'name' => t('Start Date'),
+        'type' => 'select',
+        'expose_list' => TRUE,
+        'value' => 0,
+        'exposed_empty_option' => t('Automatic'),
+      );
+      $fields['membership_start_date_memberships'] = array (
+        'name' => t('Select Membership Types'),
+        'type' => 'select',
+        'expose_list' => TRUE,
+        'extra' => array('multiple' => 1),
+      );
+      $fields['membership_end_date_rules'] = array(
+        'name' => t('End Date'),
+        'type' => 'select',
+        'expose_list' => TRUE,
+        'value' => 0,
+        'exposed_empty_option' => t('Automatic'),
+      );
+      $fields['membership_end_date_memberships'] = array (
+        'name' => t('Select Membership Types'),
+        'type' => 'select',
+        'expose_list' => TRUE,
+        'extra' => array('multiple' => 1),
+      );
+      $fields['membership_pro_rate_membership'] = array(
+        'name' => t('Pro-rate Price of Membership'),
+        'type' => 'checkbox',
+      );
     }
     // CiviGrant fields
     if (isset($sets['grant'])) {

--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -1235,7 +1235,7 @@ function wf_crm_get_fields($var = 'fields') {
         'type' => 'select',
         'expose_list' => TRUE,
         'value' => 0,
-        'exposed_empty_option' => t('Automatic'),
+        'exposed_empty_option' => '- ' . t('Automatic') . ' -',
       );
       $fields['membership_start_date_memberships'] = array (
         'name' => t('Select Membership Types'),
@@ -1248,17 +1248,13 @@ function wf_crm_get_fields($var = 'fields') {
         'type' => 'select',
         'expose_list' => TRUE,
         'value' => 0,
-        'exposed_empty_option' => t('Automatic'),
+        'exposed_empty_option' => '- ' . t('Automatic') . ' -',
       );
       $fields['membership_end_date_memberships'] = array (
         'name' => t('Select Membership Types'),
         'type' => 'select',
         'expose_list' => TRUE,
         'extra' => array('multiple' => 1),
-      );
-      $fields['membership_pro_rate_membership'] = array(
-        'name' => t('Pro-rate Price of Membership'),
-        'type' => 'checkbox',
       );
     }
     // CiviGrant fields

--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -984,6 +984,37 @@ class wf_crm_admin_form {
             }
           }
         }
+
+        // Pro rate price checkbox
+        $fieldName = 'pro_rate_memberships';
+        $fidProRate = "civicrm_{$c}_membership_{$n}_membership_{$fieldName}";
+        $this->form['membership'][$c]['membership'][$fs][$fidProRate] = array(
+          '#type' => 'checkbox',
+          '#title' => t('Pro Rate price of Membership').'&nbsp;<span class="crm-container"><a class="helpicon" href="#membership_pro_rate_membership">&nbsp;</a></span>',
+          '#default_value' => !empty($this->settings['data']['membership'][$c]['membership'][$n][$fieldName]),
+        );
+        // Handle dependent fields for membership date rules.
+        $dependentFields = array (
+          array (
+            'field' => "civicrm_{$c}_membership_{$n}_membership_start_date_memberships",
+            'depends_on' => "civicrm_{$c}_membership_{$n}_membership_start_date_rules",
+          ),
+          array (
+            'field' => "civicrm_{$c}_membership_{$n}_membership_end_date_memberships",
+            'depends_on' => "civicrm_{$c}_membership_{$n}_membership_end_date_rules",
+          ),
+          array (
+            'field' => "civicrm_{$c}_membership_{$n}_membership_pro_rate_memberships",
+            'depends_on' => "civicrm_{$c}_membership_{$n}_membership_end_date_rules",
+          ),
+        );
+        foreach ($dependentFields as $dependentField) {
+          $this->form['membership'][$c]['membership'][$fs][$dependentField['field']]['#states'] = array (
+            'visible' => array (
+              ":input[name='{$dependentField['depends_on']}']" => array ('value' => 2),
+            ),
+          );
+        }
       }
     }
   }
@@ -1311,7 +1342,7 @@ class wf_crm_admin_form {
       }
       // Remove 'create_civicrm_webform_element' option for membership date rules
       if (strpos($field['form_key'], '_start_date_rules') !== FALSE
-          || 
+          ||
           strpos($field['form_key'], '_start_date_memberships') !== FALSE
           ||
           strpos($field['form_key'], '_end_date_rules') !== FALSE
@@ -1547,6 +1578,9 @@ class wf_crm_admin_form {
           if (!in_array($ent, array('contact', 'participant', 'membership')) || isset($this->data['contact'][$c])) {
             $this->data[$ent][$c][$table][$n][$name] = $val;
           }
+        }
+        if ($name == 'pro_rate_memberships') {
+          $this->data[$ent][$c][$table][$n][$name] = $val;
         }
       }
     }

--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -1312,8 +1312,13 @@ class wf_crm_admin_form {
       // Remove 'create_civicrm_webform_element' option for membership date rules
       if (strpos($field['form_key'], '_start_date_rules') !== FALSE
           || 
-          strpos($field['form_key'], '_start_date_memberships') !== FALSE) {
-           unset($options['create_civicrm_webform_element']);
+          strpos($field['form_key'], '_start_date_memberships') !== FALSE
+          ||
+          strpos($field['form_key'], '_end_date_rules') !== FALSE
+          ||
+          strpos($field['form_key'], '_end_date_memberships') !== FALSE
+      ) {
+        unset($options['create_civicrm_webform_element']);
       }
       $options += wf_crm_field_options($field, 'config_form', $this->data);
       $item += array(

--- a/includes/wf_crm_admin_help.inc
+++ b/includes/wf_crm_admin_help.inc
@@ -320,6 +320,19 @@ class wf_crm_admin_help {
         <p>If so it will set the start date of the new membership to be the day following the end date of the existing active membership.</p>
         <p>If the user currently has multiple relevant membership types the start date will be one day following the end date of the membership with the latest end date.</p>');
   }
+
+  public static function membership_end_date_rules() {
+    print '<p>'.
+      t('"Automatic" indicates that new membership end date will be calculated according to the start date and the membership duration').
+      '</p>';
+  }
+
+  public static function membership_pro_rate_membership() {
+    print '<p>'.
+      t('If this box is ticket, the membership price will be calculated based on the number of days left until the end date compared to the number of days in a regular membership period').
+      '</p>';
+  }
+
   public static function membership_fee_amount() {
     print '<p>' .
       t('Price for this membership per term. If this field is enabled, the default minimum membership fee from CiviCRM membership type settings will not be loaded.') .

--- a/includes/wf_crm_admin_help.inc
+++ b/includes/wf_crm_admin_help.inc
@@ -308,11 +308,12 @@ class wf_crm_admin_help {
       '</p>';
   }
 
+  
   public static function membership_start_date_rules() {
     print '<p>'.
       t('\'Automatic\' indicates that the start date will follow normal CiviCRM rules. i.e. New memberships will start immediately from date of sign-up and renewals will extend memberships.').
       '</p><br /><p>'.
-      t('User select will create a new webform date component that the administrator can configure in many ways including adding a fixed or relative start or end date.').'</p>'.
+      t('\'User select\' will create a new webform date component that the administrator can configure in many ways including adding a fixed or relative start or end date.').'</p>'.
       '</p><br /><p>'.
       t('\'Relative to active membership end date\' will modify the start date of the new membership as follows:
         <p>It will first check whether the user has an existing membership of this type. If so it will follow the automatic membership rules.</p>
@@ -320,16 +321,27 @@ class wf_crm_admin_help {
         <p>If so it will set the start date of the new membership to be the day following the end date of the existing active membership.</p>
         <p>If the user currently has multiple relevant membership types the start date will be one day following the end date of the membership with the latest end date.</p>');
   }
-
+  
   public static function membership_end_date_rules() {
     print '<p>'.
       t('"Automatic" indicates that new membership end date will be calculated according to the start date and the membership duration').
       '</p>';
   }
-
+  
   public static function membership_pro_rate_membership() {
     print '<p>'.
-      t('If this box is ticket, the membership price will be calculated based on the number of days left until the end date compared to the number of days in a regular membership period').
+      t('If this box is ticked, the membership price will be calculated based on the number of days left until the end date compared to the number of days in a regular membership period').
+      '</p>';
+  }
+   public static function membership_start_date_memberships() {
+    print '<p>'.
+      t('If you do not select a membership type, new membership will start immediately once the current active membership with the latest end date has expired.').
+      '</p>';
+  }
+  
+  public static function membership_end_date_memberships() {
+    print '<p>'.
+      t('If you do not select a membership type, new membership will end when the current active membership with the latest end date expires.').
       '</p>';
   }
 

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -83,6 +83,11 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       $this->loadMultiPageData();
       $this->validateParticipants();
     }
+    
+    // Validate end dates as per membership date rules.
+    if(!empty($this->data['membership'])) {
+      $this->validateMembershipDateRules();
+    }
 
     // Process live contribution. If the transaction is unsuccessful it will trigger a form validation error.
     if ($this->contribution_page) {
@@ -102,6 +107,35 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     // Even though this object is destroyed between page submissions, this trick allows us to persist some data - see above
     $form_state['civicrm']['ent'] = $this->ent;
     $form_state['civicrm']['line_items'] = $this->line_items;
+  }
+  
+  /**
+   * Validate function for membership date rules.
+   */
+  public function validateMembershipDateRules() {
+    if (!empty($this->data['membership'])) {
+      foreach ($this->ent['contact'] as $c => $contact) {
+        if ($contact['id'] && isset($this->all_sets['membership']) && !empty($this->data['membership'][$c]['number_of_membership'])) {
+          $isError = FALSE;
+          $membershipFieldName = '';
+          foreach (wf_crm_aval($this->data, "membership:$c:membership", array()) as $n => $params) {
+            $params = $this->processMembershipDateRules($contact['id'], $params, $c, $n);
+            $membershipFieldName = "civicrm_{$c}_membership_{$n}_membership_membership_type_id";
+            if (!empty($params['end_date_rules']) && $params['end_date_rules'] == 2 && empty($params['end_date'])) {
+              $isError = TRUE;
+              break;
+            }
+            elseif (!empty($params['end_date']) && (strtotime($params['end_date']) < time())) {
+              $isError = TRUE;
+              break;
+            }
+          }
+          if ($isError) {
+            form_set_error($membershipFieldName, 'Unfortuntately you cannot purchase this item as your membership has expired.');
+          }
+        }
+      }
+    }
   }
 
   /**
@@ -1186,10 +1220,10 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       $params['contact_id'] = $cid;
       // The api won't let us manually set status without this weird param
       $params['skipStatusCal'] = !empty($params['status_id']);
-
-      // Process date rules only for new memberships
+      
+      // Process date rules only for new memberships.
       if (!isset($params['id'])) {
-        $params = $this->processMembershipDateRules($cid, $params);
+        $params = $this->processMembershipDateRules($cid, $params, $c, $n);
       }
 
       $result = wf_civicrm_api('membership', 'create', $params);
@@ -1219,26 +1253,38 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     }
   }
 
-  /**
+ /**
    * Process membership date rules
    */
-  private function processMembershipDateRules($cid, $params) {
+  private function processMembershipDateRules($cid, $params, $c, $n) {
     $membershipParams = array (
       'sequential' => 1,
       'active_only' => 1,
       'contact_id' => $cid,
       'options' => array ('sort' => "end_date DESC", 'limit' => 1),
     );
-
+    $rawValues = _webform_client_form_submit_flatten($this->node, wf_crm_aval($this->form_state, 'values:submitted'));
+    
     // Process start date rules.
-    if (!empty($params['start_date_rules']) && $params['start_date_rules'] == 2){
+    if (!empty($params['start_date_rules']) && $params['start_date_rules'] == 1) {
+      $fieldName = 'rule_start_date';
+      $fieldKey = "civicrm_{$c}_membership_{$n}_membership_{$fieldName}";
+      $componentId = $this->getComponent($fieldKey)['cid'];
+      if (!empty($params['rule_start_date'])) {
+        $params['start_date'] = $params['rule_start_date'];
+      }
+      elseif (!empty($rawValues[$componentId])) {
+        $params['start_date'] = $rawValues[$componentId]['year'] . '-' . $rawValues[$componentId]['month'] . '-' . $rawValues[$componentId]['day']; 
+      }
+    }
+    elseif (!empty($params['start_date_rules']) && $params['start_date_rules'] == 2){
       // Handle case when memberships are selected for start date rules.
       if (!empty($params['start_date_memberships'])) {
         $membershipParams['membership_type_id'] = array (
           'IN' => $params['start_date_memberships']
         );
       }
-
+      
       $activeMemberships = civicrm_api3('Membership', 'get', $membershipParams);
       if ($activeMemberships['count']) {
         $activeMembershipsEndDate = new DateTime($activeMemberships['values'][0]['end_date']);
@@ -1246,9 +1292,20 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         $params['start_date'] = $start_date->format('Ymd');
       }
     }
-
+    
     // Process end date rules.
-    if (!empty($params['end_date_rules']) && $params['end_date_rules'] == 2) {
+    if (!empty($params['end_date_rules']) && $params['end_date_rules'] == 1) {
+      $fieldName = 'rule_end_date';
+      $fieldKey = "civicrm_{$c}_membership_{$n}_membership_{$fieldName}";
+      $componentId = $this->getComponent($fieldKey)['cid'];
+      if (!empty($params['rule_end_date'])) {
+        $params['end_date'] = $params['rule_end_date'];
+      }
+      elseif (!empty($rawValues[$componentId])) {
+        $params['start_date'] = $rawValues[$componentId]['year'] . '-' . $rawValues[$componentId]['month'] . '-' . $rawValues[$componentId]['day']; 
+      }
+    }
+    elseif (!empty($params['end_date_rules']) && $params['end_date_rules'] == 2) {
       // Handle case when memberships are selected for end date rules.
       if (!empty($params['end_date_memberships'])) {
         $membershipParams['membership_type_id'] = array (
@@ -1258,6 +1315,9 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       $activeMemberships = civicrm_api3('Membership', 'get', $membershipParams);
       if ($activeMemberships['count']) {
         $activeMembershipsEndDate = $activeMemberships['values'][0]['end_date'];
+        if (empty($params['start_date'])) {
+          $params['start_date'] = date('Y-m-d');
+        }
         $params['end_date'] = $activeMembershipsEndDate;
       }
     }
@@ -1603,6 +1663,16 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
               $membership_financialtype = $item['financial_type_id'];
             };
 
+            // Pro rate logic.
+            if (!empty($item['end_date_rules'])
+                &&
+                !empty($item['pro_rate_memberships'])
+                &&
+                $item['end_date_rules'] == 2
+            ) {
+              $price = $this->pro_rated_membership_fee($type, $price, $c, $item);
+            }
+
             if ($price) {
               $this->line_items[] = array(
                 'qty' => $item['num_terms'],
@@ -1640,6 +1710,39 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       }
     }
     return round($this->totalContribution, 2);
+  }
+
+ /**
+   * Calculate pro rated membership fee.
+   * @param Integer $type
+   * @param Float $price
+   * @param Integer $c
+   * @param Array $item
+   * @return Float $price
+   */
+  private function pro_rated_membership_fee($type, $price, $c, $n, $item) {
+    $durationInterval = $this->getMembershipTypeField($type, 'duration_interval');
+    $durationUnit = $this->getMembershipTypeField($type, 'duration_unit');
+
+     // Calculate price/day.
+    $dateToday = date('Y-m-d');
+    $dateAfterGiveDuration = date('Y-m-d', strtotime("{$dateToday} +{$durationInterval} {$durationUnit}"));
+    $dateToday = date_create($dateToday);
+    $dateAfterGiveDuration = date_create($dateAfterGiveDuration);
+    $durationInDays = date_diff($dateToday, $dateAfterGiveDuration)->format('%a');
+
+    $pricePerDay = $price / $durationInDays;
+
+    // Find number of pro rate days.
+    $params = $this->processMembershipDateRules($this->existing_contacts[$c], $item, $c, $n);
+    $start_date = date_create($params['start_date']);
+    $end_date = date_create($params['end_date']);
+    $proRateDays = date_diff($start_date, $end_date)->format('%a');
+
+    // Calculate Pro Rated membership fee.
+    $price = $pricePerDay * $proRateDays;
+    
+    return $price;
   }
 
   /**

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1223,15 +1223,16 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
    * Process membership date rules
    */
   private function processMembershipDateRules($cid, $params) {
-    if (!empty($params['start_date_rules']) && $params['start_date_rules'] == 2) {
-      // fetch existing membership having latest end_date
-      $membershipParams = array (
-        'sequential' => 1,
-        'active_only' => 1,
-        'contact_id' => $cid,
-        'options' => array ('sort' => "end_date DESC", 'limit' => 1),
-      );
-      // Handle case when memberships are selected for start date rules
+    $membershipParams = array (
+      'sequential' => 1,
+      'active_only' => 1,
+      'contact_id' => $cid,
+      'options' => array ('sort' => "end_date DESC", 'limit' => 1),
+    );
+
+    // Process start date rules.
+    if (!empty($params['start_date_rules']) && $params['start_date_rules'] == 2){
+      // Handle case when memberships are selected for start date rules.
       if (!empty($params['start_date_memberships'])) {
         $membershipParams['membership_type_id'] = array (
           'IN' => $params['start_date_memberships']
@@ -1243,6 +1244,21 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         $activeMembershipsEndDate = new DateTime($activeMemberships['values'][0]['end_date']);
         $start_date = $activeMembershipsEndDate->modify('+1 day');
         $params['start_date'] = $start_date->format('Ymd');
+      }
+    }
+
+    // Process end date rules.
+    if (!empty($params['end_date_rules']) && $params['end_date_rules'] == 2) {
+      // Handle case when memberships are selected for end date rules.
+      if (!empty($params['end_date_memberships'])) {
+        $membershipParams['membership_type_id'] = array (
+          'IN' => $params['end_date_memberships']
+        );
+      }
+      $activeMemberships = civicrm_api3('Membership', 'get', $membershipParams);
+      if ($activeMemberships['count']) {
+        $activeMembershipsEndDate = $activeMemberships['values'][0]['end_date'];
+        $params['end_date'] = $activeMembershipsEndDate;
       }
     }
     return $params;

--- a/js/webform_civicrm_admin.js
+++ b/js/webform_civicrm_admin.js
@@ -512,6 +512,7 @@ var wfCiviAdmin = (function ($, D) {
           $target.show();
         }
       }).change();
+
       $('select[name$=_membership_start_date_rules]', context).change(function(e, type) {
         var $dateRuleMembershipField = $(this).parent().siblings('[class$="-start-date-memberships"]');
         var $relativeToExistingMembership = 2;
@@ -522,6 +523,18 @@ var wfCiviAdmin = (function ($, D) {
           $dateRuleMembershipField.hide();
         }
       }).trigger('change', 'init');
+      
+      $('select[name$=_membership_end_date_rules]', context).change(function(e, type) {
+        var $dateRuleMembershipField = $(this).parent().siblings('[class$="-end-date-memberships"]');
+        var $relativeToExistingMembership = 2;
+        if ($(this).val() == $relativeToExistingMembership) {
+          $dateRuleMembershipField.show();
+        }
+        else {
+          $dateRuleMembershipField.hide();
+        }
+      }).trigger('change', 'init');
+
       function billingMessages() {
         var $pageSelect = $('[name=civicrm_1_contribution_1_contribution_contribution_page_id]');
         // Warning about contribution page with no email

--- a/js/webform_civicrm_admin.js
+++ b/js/webform_civicrm_admin.js
@@ -493,9 +493,34 @@ var wfCiviAdmin = (function ($, D) {
 
       // Membership constraints
       $('select[name$=_membership_num_terms]', context).once('crm-mem-date').change(function(e, type) {
-        var $dateWrappers = $(this).parent().siblings('[class$="-date"]').not('[class$="-status-override-end-date"]');
+        var $dateWrappers = $(this).parent().siblings('[class$="-date"]').not('[class$="-status-override-end-date"]')
+                .not('[class$="-rule-start-date"]').not('[class$="-rule-end-date"]');
         if ($(this).val() == '0') {
           $dateWrappers.show();
+          if (type !== 'init') {
+            $('input', $dateWrappers).prop('checked', true);
+          }
+        }
+        else {
+          $dateWrappers.hide().find('input').prop('checked', false);
+        }
+      }).trigger('change', 'init');
+      $('select[name$=_membership_start_date_rules]', context).change(function(e, type) {
+        var $dateWrappers = $(this).parent().siblings('[class$="membership-rule-start-date"]');
+        $dateWrappers.show();
+        if ($(this).val() == '1') {
+          if (type !== 'init') {
+            $('input', $dateWrappers).prop('checked', true);
+          }
+        }
+        else {
+          $dateWrappers.hide().find('input').prop('checked', false);
+        }
+      }).trigger('change', 'init');
+      $('select[name$=_membership_end_date_rules]', context).change(function(e, type) {
+        var $dateWrappers = $(this).parent().siblings('[class$="membership-rule-end-date"]');
+        $dateWrappers.show();
+        if ($(this).val() == '1') {
           if (type !== 'init') {
             $('input', $dateWrappers).prop('checked', true);
           }
@@ -512,28 +537,6 @@ var wfCiviAdmin = (function ($, D) {
           $target.show();
         }
       }).change();
-
-      $('select[name$=_membership_start_date_rules]', context).change(function(e, type) {
-        var $dateRuleMembershipField = $(this).parent().siblings('[class$="-start-date-memberships"]');
-        var $relativeToExistingMembership = 2;
-        if ($(this).val() == $relativeToExistingMembership) {
-          $dateRuleMembershipField.show();
-        }
-        else {
-          $dateRuleMembershipField.hide();
-        }
-      }).trigger('change', 'init');
-      
-      $('select[name$=_membership_end_date_rules]', context).change(function(e, type) {
-        var $dateRuleMembershipField = $(this).parent().siblings('[class$="-end-date-memberships"]');
-        var $relativeToExistingMembership = 2;
-        if ($(this).val() == $relativeToExistingMembership) {
-          $dateRuleMembershipField.show();
-        }
-        else {
-          $dateRuleMembershipField.hide();
-        }
-      }).trigger('change', 'init');
 
       function billingMessages() {
         var $pageSelect = $('[name=civicrm_1_contribution_1_contribution_contribution_page_id]');


### PR DESCRIPTION
**Overview:**
In Webform/CiviCRM it is not possible 
1. To specify the end date of a new membership.
2. Calculate pro-rate for membership.

**Solution:**
This PR adds the functionality to 
1. Specify End date for a membership.
2. Calculate pro-rate for a membership based on the formula below:

> Pro-rated membership fee = (regular membership fee/ number of days in regular membership period) x number of days in pro-rated membership period