### PR TITLE
Add 'colemanw/webform_civicrm/pull/178' Required To Work With Latest CiviCRM Core

### DIFF
--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -864,11 +864,18 @@ abstract class wf_crm_webform_base {
    * @return int|null
    */
   function addPaymentJs() {
-    $credit_card_types = CRM_Core_Payment_Form::getCreditCardCSSNames();
-    CRM_Core_Resources::singleton()
-      ->addCoreResources()
-      ->addSetting(array('config' => array('creditCardTypes' => $credit_card_types)))
-      ->addScriptFile('civicrm', 'templates/CRM/Core/BillingBlock.js', -10, 'html-header');
+    $currentVer = CRM_Core_BAO_Domain::version();
+    if (version_compare($currentVer, '5.8') <= 0 && method_exists('CRM_Core_Payment_Form', 'getCreditCardCSSNames')) {
+      $credit_card_types = CRM_Core_Payment_Form::getCreditCardCSSNames();
+      CRM_Core_Resources::singleton()
+        ->addCoreResources()
+        ->addSetting(array('config' => array('creditCardTypes' => $credit_card_types)))
+        ->addScriptFile('civicrm', 'templates/CRM/Core/BillingBlock.js', -10, 'html-header');
+    }
+    else {
+      CRM_Core_Resources::singleton()->addCoreResources();
+      CRM_Financial_Form_Payment::addCreditCardJs(NULL, 'html-header');
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This version of webform_civicrm requires https://github.com/colemanw/webform_civicrm/pull/178/ to work with the latest version of Civicrm. The core issue related to this is https://github.com/civicrm/civicrm-core/pull/12615/files

Before
----------------------------------------
webform_civirm throws fatal error

After
----------------------------------------
No errors

Technical Details
----------------------------------------
Core removed the method ContributionBase::getCreditCardCSSNames(). This is used in webform_civicrm and needed to be fixed.
