### PR TITLE
PSA-162: Handle Optgroups In Backend Instead Of In JS

### DIFF
--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -474,6 +474,25 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
               webform_component_update($component);
             }
             $element['#options'] = $new;
+	    // Handle optgroups.
+            // CiviCRM treats options that start with 'crm_optgroup' as optgroup
+            // We create nested options for optgroups as Drupal FAPI expects
+            $groupedOptions = [];
+            $group = NULL;
+	    foreach ($element['#options'] as $key => $val) {
+              if (strpos($key, 'crm_optgroup') === 0) {
+                $group = $val;
+                $groupedOptions[$group] = [];
+                continue;
+              }
+              if ($group) {
+                $groupedOptions[$group][$key] = $val;
+              }
+              else {
+                $groupedOptions[$key] = $val;
+              }
+            }
+            $element['#options'] = $groupedOptions;
           }
           // If the user has already entered a value for this field, don't change it
           if (isset($this->info[$ent][$c][$table][$n][$name])

--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -392,12 +392,6 @@ var wfCivi = (function ($, D) {
         }
       });
 
-      // Support CiviCRM's quirky way of doing optgroups
-      $('option[value^=crm_optgroup]', context).each(function () {
-        $(this).nextUntil('option[value^=crm_optgroup]').wrapAll('<optgroup label="' + $(this).text() + '" />');
-        $(this).remove();
-      });
-
       // Add handler to country field to trigger ajax refresh of corresponding state/prov
       $('form.webform-client-form .civicrm-enabled[name*="_address_country_id]"]').once('civicrm').change(countrySelect);
 


### PR DESCRIPTION
Overview
----------------------------------------
Select fields with 'optgroups' are handled in frontend JS code in webform_civicrm. Though this works, this method breaks using frontend modules like 'chosen' in Drupal. This breaks the select options and leads to problems.
This PR moves handling of 'optgroups' to the backend and so works fine with other FE modules (tested with 'chosen')

Before
----------------------------------------
'optgroups' handled in JS using DOM manipulation

After
----------------------------------------
'optgroups' handled in backend code

Technical Details
----------------------------------------
In Drupal form api, optgroups can be added by nesting arrays. So in backend, the options are traversed and a nested array according to optgroups is built. Drupal form api then renders this as expected.
