### PR TITLE
BASW-394: Handle Custom Date Fields When Set Via Webform Conditionals

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -109,7 +109,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
    * @see webform_civicrm_webform_submission_presave
    * @param stdClass $submission
    */
-  public function preSave(&$submission) {
+  public function preSave(&$submission, $formatDate = FALSE) {
     $this->submission = &$submission;
     $this->data = $this->settings['data'];
     // Check for existing submission
@@ -122,7 +122,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       return;
     }
 
-    $this->fillDataFromSubmission();
+    $this->fillDataFromSubmission($formatDate);
 
     // Create/update contacts
     foreach ($this->data['contact'] as $c => $contact) {
@@ -2312,7 +2312,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
   /**
    * Fill data array with submitted form values
    */
-  private function fillDataFromSubmission() {
+  private function fillDataFromSubmission($formatDate = FALSE) {
     foreach ($this->enabled as $field_key => $fid) {
       $val = $this->submissionValue($fid);
       // If value is null then it was hidden by a webform conditional rule - skip it
@@ -2376,6 +2376,10 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
             $time = substr($time, -6);
           }
           $val .= $time;
+          if ($formatDate) {
+            $val = new DateTime($val);
+            $val = $val->format('YmdHis');
+          }
         }
         // The admin can change a number field to use checkbox/radio/select/grid widget and we'll sum the result
         elseif ($field['type'] === 'number') {

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -252,8 +252,26 @@ function webform_civicrm_webform_component_info() {
 function webform_civicrm_webform_submission_presave($node, &$submission) {
   if (!empty($node->webform_civicrm)) {
     module_load_include('inc', 'webform_civicrm', 'includes/wf_crm_webform_postprocess');
+
+    $formatDate = FALSE;
+    foreach ($node->webform['components'] as $component) {
+      if (strpos($component['form_key'], 'civicrm_') === 0 && strpos($component['form_key'], '_custom_')) {
+        // custom field
+        $form_key_items = explode('_', $component['form_key']);
+        $custom_field_id = array_pop($form_key_items);
+        civicrm_initialize();
+        $result = civicrm_api3('CustomField', 'getSingle', [
+          'sequential' => 1,
+          'id' => $custom_field_id,
+        ]);
+        if ($result['data_type'] == 'Date') {
+          $formatDate = TRUE;
+        }
+      }
+    }
+
     $processor = wf_crm_webform_postprocess::singleton($node);
-    $processor->preSave($submission);
+    $processor->preSave($submission, $formatDate);
   }
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
Setting conditional values for custom fields in webforms has issues if the custom field is of 'Date' type and a 'hidden' type widget is used for the webform field.
This PR fixes this by handling such fields and formatting them to 'Date'type accepted format.

Before
----------------------------------------
Setting a custom civicrm date type field via webform conditionals wont work.

After
----------------------------------------
Now custom civicrm date type fields can be set using webform conditionals and the submission works as expected.