### PR TITLE
RSE-1204: Change button label from 'Change' to 'Remove' to match drupal naming

### DIFF
--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -101,7 +101,7 @@ var wfCivi = (function ($, D) {
       }
       else {
         $(container).children().hide();
-        container.append('<input type="submit" class="form-submit ajax-processed civicrm-remove-file" value="' + Drupal.t('Change') + '" onclick="wfCivi.clearFileField(\'' + field + '\'); return false;">');
+        container.append('<input type="submit" class="form-submit ajax-processed civicrm-remove-file" value="' + Drupal.t('Remove') + '" onclick="wfCivi.clearFileField(\'' + field + '\'); return false;">');
       }
       container.prepend('<span class="civicrm-file-icon"><img alt="' + Drupal.t('File') + '" src="' + info.icon + '" /> ' + (info.name ? ('<a href="'+ info.file_url+ '" target="_blank">'+info.name +'</a>') : '') + '</span>');
     }


### PR DESCRIPTION
Overview
----------------------------------------
There is a `Change` button next to the civicrm image (i.e. contact profile image) field on webforms. And in this PR it's label is changed to `Remove` to follow drupal button naming ([example](https://nimb.ws/lgno51)).
This also would help to avoid confusions if user wants just to remove the image (don't want to upload another one).

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/39520000/86447235-b6651300-bd1d-11ea-9c5c-fcda1c691eb2.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/39520000/86447176-a1887f80-bd1d-11ea-809d-8ab692a689fa.png)