### PR TITLE
CATL-1034: Allow updating case type of an existing case

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1278,7 +1278,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         else {
           $params['id'] = $this->ent['case'][$n]['id'];
           // These params aren't allowed in update mode
-          unset($params['creator_id'], $params['case_type_id']);
+          unset($params['creator_id']);
         }
         // Allow "automatic" status to pass-thru
         if (empty($params['status_id'])) {

--- a/webform_civicrm.info
+++ b/webform_civicrm.info
@@ -6,3 +6,5 @@ php = 7.0
 dependencies[] = civicrm (>=5.12)
 dependencies[] = webform (>=4.19)
 dependencies[] = options_element
+
+; patch 1


### PR DESCRIPTION
Overview
----------------------------------------
Updating case type for an existing case is not possible using webform civicrm. As part of this PR we are making it possible to be able to update case types for a case using webform.
PR: https://github.com/colemanw/webform_civicrm/pull/337

Before
----------------------------------------
![CATL-1034-before](https://user-images.githubusercontent.com/7393885/89532891-23cdfd00-d810-11ea-8bec-d825c405fd4f.gif)


After
----------------------------------------
![CATL-1034-after](https://user-images.githubusercontent.com/7393885/89532859-1a449500-d810-11ea-9124-9b267b09f14c.gif)



Technical Details
----------------------------------------
In function `processCases` the field `case_type_id` was unset when the case is updated, because of which it doesn't update case type in CiviCRM.
Removed the key to prevent it from getting unset.

Comments
----------------------------------------