### PR TITLE
CATL-1465: Fix case contact loading

### DIFF
--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -271,7 +271,7 @@ abstract class wf_crm_webform_base {
         case 'case_roles':
           $to = $component['extra']['default_relationship_to'];
           $case = $component['extra']['default_for_case'];
-          if (empty($this->ent['contact'][$c]['id'])) {
+          if (empty($this->ent['contact'][$c]['id']) && $component['extra']['default_case_roles'] == 'case_client') {
             // load case client of case (if passed in URL) as default contact
             $this->findCaseClientForDefaultContact($c);
           }

--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -612,8 +612,10 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
   }
 
  /**
-   * Function to load default contact (cid1) if default loading is set to case_roles
-   */
+  * Function to load default contact (cid1) if default loading is set to case_roles
+  *
+  * @param int $c
+  */
   function findCaseClientForDefaultContact($c) {
     // Support legacy url param
     if (empty($_GET["case1"]) && !empty($_GET["caseid"])) {
@@ -627,7 +629,6 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
         if (count($clients) > 0) {
           $caseClient = reset($clients);
           $this->ent['contact'][$c]['id'] = $caseClient;
-          return;
         }
       }
     }

--- a/webform_civicrm.info
+++ b/webform_civicrm.info
@@ -7,4 +7,4 @@ dependencies[] = civicrm (>=5.12)
 dependencies[] = webform (>=4.19)
 dependencies[] = options_element
 
-; patch 1
+; patch 2


### PR DESCRIPTION
Overview
----------------------------------------
When there are case contact fields on webform which do not have any contact associated with them in civi yet, then those fields currently get filled by the **case client**. 
Expected behaviour is that these fields remain empty since they do not have a contact for that case role.
PR: https://github.com/colemanw/webform_civicrm/pull/329

Before
----------------------------------------
Contact IDs are replaced by case_client ID if that case role doesn’t exist on the case yet
![screenshot(1)](https://user-images.githubusercontent.com/7393885/88626333-1b671b00-d0c8-11ea-9f76-369ae6da6d05.png)


After
----------------------------------------
Contact IDs are not replaced by the case client and instead remain empty as they should be.
![screenshot](https://user-images.githubusercontent.com/7393885/88626353-20c46580-d0c8-11ea-8ea4-9a18fe95e00c.png)


Technical Details
----------------------------------------
`function findCaseClientForDefaultContact` is reponsible for finding case client for the case.
The above function was replacing the contact id,  for case role that doesn't exist, with case client ID, which should be 0 in case if the case role contact is not present for the case yet.
To fix that, we have added additional check for the case role and then fixing `$this->ent['contact'][$c]['id']` accordingly.
