### PR TITLE
 CATL-1564: Handle hidden (select) fields in submissions and emails

### DIFF
--- a/webform_civicrm.info
+++ b/webform_civicrm.info
@@ -7,4 +7,4 @@ dependencies[] = civicrm (>=5.12)
 dependencies[] = webform (>=4.19)
 dependencies[] = options_element
 
-; patch 2
+; patch 3

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -325,11 +325,39 @@ function webform_civicrm_webform_submission_load(&$submissions) {
 
 /**
  * Implements hook_webform_submission_render_alter().
- * Add display name to title while viewing a submission.
  */
-function webform_civicrm_webform_submission_render_alter(&$sub) {
-  if (!empty($sub['#submission']->civicrm['contact'][1]['display_name']) && empty($sub['#email']) && $sub['#format'] == 'html') {
-    drupal_set_title(t('Submission #!num by @name', ['!num' => $sub['#submission']->sid, '@name' => $sub['#submission']->civicrm['contact'][1]['display_name']]));
+function webform_civicrm_webform_submission_render_alter(&$renderable) {
+  // Add display name to title while viewing a submission.
+  if (!empty($renderable['#submission']->civicrm['contact'][1]['display_name']) && empty($renderable['#email']) && $renderable['#format'] == 'html') {
+    drupal_set_title(t('Submission #!num by @name', ['!num' => $renderable['#submission']->sid, '@name' => $renderable['#submission']->civicrm['contact'][1]['display_name']]));
+  }
+
+  // Show labels for hidden (select) fields when submissions are rendered.
+  foreach ($renderable['#node']->webform['components'] as $component) {
+    if ($component['type'] == 'hidden') {
+      $options = wf_crm_field_options($component, 'submission', $renderable['#node']->webform_civicrm['data']);
+      if (empty($options)) {
+        return;
+      }
+      $parentkeys = webform_component_parent_keys($renderable['#node'], $component);
+      $value = &$renderable[array_shift($parentkeys)];
+      foreach ($parentkeys as $parentkey) {
+        $value = &$value[$parentkey];
+      }
+
+      // Handle multiple values.
+      if (!empty($component['extra']['multiple'])) {
+        $selected_options = explode(',', $value['#markup']);
+        $items = [];
+        foreach ($selected_options as $selected_option) {
+          $items[] = $options[$selected_option];
+        }
+        $value['#markup'] = implode(', ', $items);
+      }
+      else {
+        $value['#markup'] = $options[$value['#markup']];
+      }
+    }
   }
 }
 


### PR DESCRIPTION

Overview
----------------------------------------
If the widget type for a civicrm select options is changed to **hidden**, then when viewing the submissions, it starts to show as IDs instead of labels.
For example, if the **country** field's widget type is changed to **hidden** then in submissions instead of showing the country name (In our case, United Kingdom), it will start to show ids (in our case, 1226).
PR: https://github.com/colemanw/webform_civicrm/pull/335

Before
----------------------------------------
**Submission**
![screenshot(8)](https://user-images.githubusercontent.com/7393885/89263706-5977b800-d64f-11ea-812f-5781710679d3.png)

**Email**
![screenshot(10)](https://user-images.githubusercontent.com/7393885/89264218-30a3f280-d650-11ea-8ff5-48b3877bfc82.png)

After
----------------------------------------
**Submission**
![screenshot(9)](https://user-images.githubusercontent.com/7393885/89263889-a8bde880-d64f-11ea-8136-c0e56bf4d4c8.png)

**Email**
![screenshot(11)](https://user-images.githubusercontent.com/7393885/89264929-5f6e9880-d651-11ea-8898-33c32f297233.png)


Technical Details
----------------------------------------
1. Handling of hidden fields, in terms of submission/email rendering, is like textfields. Meaning, whatever value they have, it is rendered as it is in submissions or emails send by webform.
2. But in our case we are making it possible to hide select fields which as a result, started showing ids instead of labels since the structure for select list and hidden fields is different.
3. To fix this, used `function webform_civicrm_webform_submission_render_alter(&$renderable)`.
4. To check if the rendered field was select or not (before making it hidden), we are using `wf_crm_field_options` which returns options if the field has any (for select fields).
5. After detecting if the field was a select field, we are processing the field values and changing them to labels.

Comments
----------------------------------------
