### PR TITLE
MAE-443: Update Webform CiviCRM V4 to include Cases Tags

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -54,14 +54,12 @@ function wf_crm_field_options($field, $context, $data) {
     elseif ($name == 'privacy') {
       $ret = wf_crm_get_privacy_options();
     }
-    elseif ($table === 'other') {
-      if ($field['table'] === 'tag') {
-        $split = explode('_', $name);
-        $ret = CRM_Core_BAO_Tag::getTags("civicrm_{$ent}", $ret, wf_crm_aval($split, 1), '- ');
-      }
-      elseif ($field['table'] === 'group') {
-        $ret = wf_crm_apivalues('group', 'get', array('is_hidden' => 0), 'title');
-      }
+    elseif (isset($field['table']) && $field['table'] === 'tag') {
+      $split = explode('_', $name);
+      $ret = CRM_Core_BAO_Tag::getTags("civicrm_{$ent}", $ret, wf_crm_aval($split, 1), '- ');
+    }
+    elseif (isset($field['table']) && $field['table'] === 'group') {
+      $ret = wf_crm_apivalues('group', 'get', array('is_hidden' => 0), 'title');
     }
     elseif ($name === 'survey_id') {
       $ret = wf_crm_get_surveys(wf_crm_aval($data, "activity:$c:activity:1", array()));
@@ -771,16 +769,6 @@ function wf_crm_get_fields($var = 'fields') {
       'table' => 'group',
       'expose_list' => TRUE,
     );
-    $tagsets = array('' => t('Tag(s)')) + CRM_Core_BAO_Tag::getTagSet('civicrm_contact');
-    foreach ($tagsets as $pid => $name) {
-      $fields['other_tag' . ($pid ? "_$pid" : '')] = array(
-        'name' => $name,
-        'type' => 'select',
-        'extra' => array('multiple' => 1, 'civicrm_live_options' => 1),
-        'table' => 'tag',
-        'expose_list' => TRUE,
-      );
-    }
     $fields['activity_activity_type_id'] = array(
       'name' => t('Activity # Type'),
       'type' => 'select',
@@ -852,7 +840,9 @@ function wf_crm_get_fields($var = 'fields') {
         'integer' => 1,
       ),
     );
+    $tag_entities = array('other', 'activity');
     if (isset($sets['case'])) {
+      $tag_entities[] = 'case';
       $case_info = new CRM_Case_XMLProcessor_Process();
       $fields['case_case_type_id'] = array(
         'name' => t('Case # Type'),
@@ -931,6 +921,29 @@ function wf_crm_get_fields($var = 'fields') {
             }
           }
         }
+      }
+    }
+    $all_tagsets = wf_crm_apivalues('tag', 'get', [
+      'return' => ['id', 'name', 'used_for'],
+      'is_tagset' => 1,
+      'parent_id' => ['IS NULL' => 1],
+    ]);
+    foreach ($tag_entities as $entity) {
+      $table_name = $entity == 'other' ? 'civicrm_contact' : "civicrm_$entity";
+      $tagsets = ['' => t('Tag(s)')];
+      foreach ($all_tagsets as $set) {
+        if (strpos($set['used_for'], $table_name) !== FALSE) {
+          $tagsets[$set['id']] = $set['name'];
+        }
+      }
+      foreach ($tagsets as $pid => $name) {
+        $fields[$entity . '_tag' . ($pid ? "_$pid" : '')] = [
+          'name' => $name,
+          'type' => 'select',
+          'extra' => ['multiple' => 1, 'civicrm_live_options' => 1],
+          'table' => 'tag',
+          'expose_list' => TRUE,
+        ];
       }
     }
     $fields['relationship_relationship_type_id'] = array(

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -900,14 +900,18 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         $params['method'] = 'Webform';
         break;
       case 'tag':
-        $api = 'entity_tag';
+        $api = 'EntityTag';
         break;
       default:
         $api = $data_type;
     }
     if (!empty($add) || !empty($remove)) {
       // Retrieve current records for this entity
-      if ($entity_type == 'contact') {
+      if ($api == 'EntityTag') {
+        $params['entity_id'] = $id;
+        $params['entity_table'] = 'civicrm_' . $entity_type;
+      }
+      elseif ($api == 'group_contact' && $entity_type == 'contact') {
         $params['contact_id'] = $id;
       }
       else {
@@ -1315,6 +1319,8 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         $result = wf_civicrm_api('case', 'create', $params);
         // Final processing if save was successful
         if (!empty($result['id'])) {
+          // handle case tags
+          $this->handleEntityTags('case', $result['id'], $n, $params);
           // Store id
           $this->ent['case'][$n]['id'] = $result['id'];
           // Save custom field data
@@ -1423,6 +1429,8 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         $activity = wf_civicrm_api('activity', 'create', $params);
         // Final processing if save was successful
         if (!empty($activity['id'])) {
+          // handle activity tags
+          $this->handleEntityTags('activity', $activity['id'], $n, $params);
           // Store id
           $this->ent['activity'][$n]['id'] = $activity['id'];
           // Save custom data & attachments
@@ -1451,6 +1459,28 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
               }
             }
           }
+        }
+      }
+    }
+  }
+
+  /**
+   * Handle adding/updating tags for entities (cases, activity)
+   *
+   * @param $entityType
+   * @param $entityId
+   * @param $n
+   * @param $params
+   */
+  function handleEntityTags($entityType, $entityId, $n, $params) {
+    foreach ($this->all_fields as $fid => $field) {
+      list($set, $type) = explode('_', $fid, 2);
+      if ($set == $entityType && isset($field['table']) && $field['table'] == 'tag') {
+        $field_name = 'civicrm_' . $n . '_' . $entityType. '_1_' . $fid;
+        if (isset($this->enabled[$field_name]) && isset($this->data[$entityType][$n])) {
+          $add = wf_crm_aval($this->data[$entityType][$n], $entityType . ":1:$type", array());
+          $remove = $this->getExposedOptions($field_name, $add);
+          $this->addOrRemoveMultivaluedData('tag', $entityType, $entityId, $add, $remove);
         }
       }
     }
@@ -2360,7 +2390,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
             $val = array_unique(array_merge($val, $this->data[$ent][$c][$table][$n][$name]));
           }
           // Implode data that will be stored as a string
-          if ($table !== 'other' && $name !== 'event_id' && $name !== 'relationship_type_id' && $table !== 'contact' && $dataType != 'ContactReference') {
+          if ($table !== 'other' && $name !== 'event_id' && $name !== 'relationship_type_id' && $table !== 'contact' && $dataType != 'ContactReference'  && strpos($name, 'tag') !== 0) {
             $val = CRM_Utils_Array::implodePadded($val);
           }
         }

--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -807,6 +807,14 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
               $this->info[$type][$n]["{$type}upload"][1]["file_$f"] = $file['file_id'];
             }
           }
+          // Load tags
+          $tags = NULL;
+          foreach (array_keys($this->enabled) as $fid) {
+            if (strpos($fid, "civicrm_{$n}_{$type}_1_{$type}_tag") === 0) {
+              $tags = $tags ?? wf_crm_apivalues('EntityTag', 'get', ['entity_id' => $id, 'entity_table' => "civicrm_" . $type, 'sequential' => 1], 'tag_id');
+              $this->info[$type][$n][$type][1][str_replace("civicrm_{$n}_{$type}_1_{$type}_", '', $fid)] = $tags;
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
As part of this PR we are backporting https://github.com/colemanw/webform_civicrm/pull/268 to our 7.x-4.28-patches branch. Tis pr has already been released as part of webform civicrm 7.x-5.0

Before
----------------------------------------
Case tags was not part of 7.x-4.28-patches branch

After
----------------------------------------
Backported case tags to 7.x-4.28-patches branch.

Comments
----------------------------------------
Please note that we are not using `wf_crm_get_tags` function as used [here](https://github.com/colemanw/webform_civicrm/pull/268/files#diff-9cb3eee9a544ffd3836c0c18ff7a0551056d9663507a2188b90380a855fcd2fdR59) because this function was not part of 4.28.
