### PR TITLE
FEMSSPRT-20: Fix viewing and storing of multi-select custom fields

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -1313,6 +1313,14 @@ function wf_crm_get_fields($var = 'fields') {
     $dao = CRM_Core_DAO::executeQuery($sql);
     while ($dao->fetch()) {
       if (isset($custom_types[$dao->html_type])) {
+        // CiviCRM changed the way it define multi-select custom fields where the HTML type will be just "select"
+        // and a new field called `serialize` will be set to 1 (or 0 if it is just a single select field).
+        // newer webform version is updated to handle that, so here I just update our forked patch to handle that as well
+        // until we update our fork to newer webform version.
+        if (!empty($dao->serialize)) {
+          $dao->html_type = 'Multi-Select';
+        }
+
         $set = 'cg' . $dao->custom_group_id;
         // Place these custom fields directly into their entity
         if (wf_crm_aval($sets, "$dao->entity_type:custom_fields") == 'combined') {


### PR DESCRIPTION
Before
----------------------------------------
IF a multi-select custom field is created : 
![2021-01-05 15_31_56-multitest - Custom Fields _ compuvag5one](https://user-images.githubusercontent.com/6275540/103652644-4d27bc00-4f5b-11eb-9978-d9006dcea9a3.png)

Then adding this custom field to the webform will show it as a single select list instead of multiple-checkboxes as it usually does.

![2021-01-05 15_36_17-test _ compuvag5one](https://user-images.githubusercontent.com/6275540/103652800-88c28600-4f5b-11eb-9a0f-77540e71428f.png)

 The reason is that CiviCRM changed the way it defines multi-select custom fields where the HTML type will be just "select"
 and a new field called `serialize` will be set to 1 (or 0 if it is just a single select field).
newer webform version is updated to handle that along with other big updates to the webform module, so here I just update our forked branch to handle that as well until we update our fork to newer webform version.


After
----------------------------------------
Multi-select custom fields show as checkboxes instead of a single select list.

![2021-01-05 15_37_28-test _ compuvag5one](https://user-images.githubusercontent.com/6275540/103652934-b7d8f780-4f5b-11eb-92be-845b92440f12.png)


and here how it show normally in the contact screen after submitting the webform : 
![2021-01-05 15_38_13-dasjia2@da com dasjia2@da com _ compuvag5one](https://user-images.githubusercontent.com/6275540/103652939-ba3b5180-4f5b-11eb-94e1-bcd06832ca9b.png)


