### PR TITLE
CATL-2102: Get Only Active Roles

### DIFF
--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -1038,6 +1038,7 @@ function wf_crm_find_case_roles($contact_a, $case, $case_role) {
     'relationship_type_id' => $case_role,
     'contact_id_a' => $contact_a,
     'case_id' => $case,
+    'is_active' => 1,
   ];
   $result = wf_civicrm_api('Relationship', 'get', $params);
   if (isset($result['values'][0]['contact_id_b'])) {


### PR DESCRIPTION
Overview
----------------------------------------
This PR solves a problem found in one of our forms, in which the current "Regional Case Worker" was not being shown, and it was displayed an old one instead.


Before
----------------------------------------
For a given role on a case, if it is changed, the relationship is marked as "inactive", with the appropriate `end_date` for it.
Later, when we access a webform that should display that relationship, only the first one is displayed, because it is not being filtered by `is_active`.

Here is an example of a field for a webform:
![image](https://user-images.githubusercontent.com/74304572/110483593-74963300-811c-11eb-978c-0a602ec4ec3b.png)

And also a list of values that the role "Regional Caseworker" could have:
![image](https://user-images.githubusercontent.com/74304572/110483753-9bed0000-811c-11eb-9519-5d4cd9e67e25.png)


After
----------------------------------------
The first active role found is displayed on the form.


