### PR TITLE
CATL-2102: Tagging version 7.x-5.1-patch5

### DIFF
--- a/webform_civicrm.info
+++ b/webform_civicrm.info
@@ -7,4 +7,4 @@ dependencies[] = civicrm (>=5.12)
 dependencies[] = webform (>=4.19)
 dependencies[] = options_element
 
-; patch 4
+; patch 5


### PR DESCRIPTION
## Release Update - 9th March, 2021

### Bug Fixes
- Get Only Active Roles For Case #30 