### PR TITLE
MAE-503: Save line item's money fields properly

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -2224,11 +2224,6 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         }
       }
 
-      // Format (and round) monetary values before saving the line items
-      isset($item['unit_price']) ? $item['unit_price'] = CRM_Utils_Money::format($item['unit_price'], NULL, NULL, TRUE) : NULL;
-      isset($item['line_total']) ? $item['line_total'] = CRM_Utils_Money::format($item['line_total'], NULL, NULL, TRUE) : NULL;
-      isset($item['tax_amount']) ? $item['tax_amount'] = CRM_Utils_Money::format($item['tax_amount'], NULL, NULL, TRUE) : NULL;
-
       // Save the line_item
       $line_result = wf_civicrm_api('line_item', 'create', $item);
       $item['id'] = $line_result['id'];


### PR DESCRIPTION
Overview
----------------------------------------
This PR fix an issue related to CiviCRM 5.35 update when trying to signup a new membership with price number has more than theree digits using Webforms, contribution's line items are saved incorrectly.

Before
----------------------------------------
The 3rd line item should be `1,200 £` instead of `1 £`
![Screenshot from 2021-03-17 19-32-47](https://user-images.githubusercontent.com/74309109/111511820-c27fec00-8757-11eb-83f9-7e5bdb0a8ba9.png)
![Screenshot from 2021-03-17 19-32-59](https://user-images.githubusercontent.com/74309109/111511860-ca3f9080-8757-11eb-885b-b86a4adcfc99.png)


After
----------------------------------------
The 3rd line item is correct.

![Screenshot from 2021-03-17 19-26-35](https://user-images.githubusercontent.com/74309109/111511895-d3306200-8757-11eb-8b0e-a00f38d76cbe.png)
![Screenshot from 2021-03-17 19-33-16](https://user-images.githubusercontent.com/74309109/111511900-d75c7f80-8757-11eb-82ad-045939785af6.png)


Technical Details
----------------------------------------
CiviCRM changed `CRM_Utils_Money::format` in the commit [e9dc52](https://github.com/civicrm/civicrm-core/pull/19099/commits/e9dc523058cf69d5b45b9ea3fa2c79204217aca7).

```php
// CiviCRM 5.28
 cv ev "echo CRM_Utils_Money::format('1200.00', NULL, NULL, TRUE);" # 1200.00
```
```php
// CiviCRM 5.35
cv ev "echo CRM_Utils_Money::format('1200.00', NULL, NULL, TRUE);" # 1,200.00
```

For decimal fields like `line_total`, `unit_price`, `tax_amount`, the value `1,200.00` we be saved as `1` during the process of saving them to the database.

The [upstream repository](https://github.com/colemanw/webform_civicrm) has two PRs https://github.com/colemanw/webform_civicrm/pull/410, https://github.com/colemanw/webform_civicrm/pull/409 to address the issue of rounding prematurely and both of them and this PR have the same code change. What a coincidence! . 
Unfortunately, the PR https://github.com/colemanw/webform_civicrm/pull/409 hasn't merged yet. I agree with the authors and decided not to apply any rounding in this PR.

