### PR TITLE
MAE-512: Bump version to 7.x-4.28-patch6

### DIFF
--- a/webform_civicrm.info
+++ b/webform_civicrm.info
@@ -6,4 +6,4 @@ package = CiviCRM
 dependencies[] = civicrm (>=4.4)
 dependencies[] = webform (>=4.12)
 dependencies[] = options_element
-; patch 5
+; patch 6


### PR DESCRIPTION
Bumping version to 7.x-4.28-patch6  as part of Membershipextras suite 4.2.0 release