### PR TITLE
PSASPRT-128: Bump patch version after PSA upgrade fixes

### DIFF
--- a/webform_civicrm.info
+++ b/webform_civicrm.info
@@ -6,4 +6,4 @@ package = CiviCRM
 dependencies[] = civicrm (>=4.4)
 dependencies[] = webform (>=4.12)
 dependencies[] = options_element
-; patch 7
+; patch 8


### PR DESCRIPTION
After upgrading PSA (and FEMs too) to the latest webform version, we discovered an issue that is described here (https://github.com/compucorp/webform_civicrm/pull/36), this release contains a fix for it.
