### PR TITLE
ACU-667: Merging 7.x-5.1-patches work to the our main 5.4 patched branch

### DIFF
--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -1036,6 +1036,7 @@ function wf_crm_find_case_roles($contact_a, $case, $case_role) {
     'relationship_type_id' => $case_role,
     'contact_id_a' => $contact_a,
     'case_id' => $case,
+    'is_active' => 1,
   ];
   $result = wf_civicrm_api('Relationship', 'get', $params);
   if (isset($result['values'][0]['contact_id_b'])) {


### PR DESCRIPTION
We before had two branches:

- 7.x-4.28-patches: Which used to contain all the webform patches we needed for V5.
- 7.x-5.1-patches: Which used to contain all the webform patches that are related to Cases and was only used for one of our clients.

But given that we upgraded 7.x-4.28-patches to 7.x-5.4-patches (which is basically upgrading to webform version 7.x-5.4 and applying the patches that were not merged to the core repo), it happened that most of the patches that were applied to 7.x-5.1-patches branch are now are already part of 7.x-5.4 core branch, and thus there is no need to reapply them to  7.x-5.4-patches branch, except for this one:

CATL-2102: https://github.com/compucorp/webform_civicrm/pull/30



After merging this PR, all of our patches will be on this branch  **7.x-5.4-patches** and I will tag a new version  7.x-5.4-patches2, which will be the version that all of our client uses instead of having different clients on different versions.