### PR TITLE
CIVIPLUS-879: Fix the payment double receipts generate issue

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -244,7 +244,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     if (empty($this->submission->is_draft)
       && !empty($this->ent['contribution'][1]['id'])
       && !empty($this->contribution_page['is_email_receipt'])
-      && (!$this->contributionIsIncomplete || $this->contributionIsPayLater)
+      && $this->contributionIsPayLater
     ) {
       $this->sendReceipt();
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fix the payment double receipts generate issue in webform

Before
----------------------------------------
Payment double receipt generate from stripe and dummy payment processor in webform.
![before](https://user-images.githubusercontent.com/107249752/186085494-02ccedb6-e3dd-4994-90d8-deb367e08fea.png)


After
----------------------------------------
![after](https://user-images.githubusercontent.com/107249752/186085522-0517209c-49e7-4ec8-b499-82ebba60df10.png)


Technical Details
----------------------------------------
We have changed the condition to send only single email receipts from webform.