### PR TITLE
CATL-2264: Clear in-relation contact reference when other contact with no relationship is selected

### DIFF
--- a/includes/wf_crm_webform_ajax.inc
+++ b/includes/wf_crm_webform_ajax.inc
@@ -137,19 +137,21 @@ class wf_crm_webform_ajax extends wf_crm_webform_base {
           elseif ($i > $c && $field == 'existing') {
             $related_component = $this->getComponent($fid);
             if (wf_crm_aval($related_component['extra'], 'default') == 'relationship') {
-              $old_related_cid = wf_crm_aval($this->ent, "contact:$i:id");
               // Don't be fooled by old data
               $related_component['extra']['allow_url_autofill'] = FALSE;
               unset($this->ent['contact'][$i]);
               $this->findContact($related_component);
               $related_cid = wf_crm_aval($this->ent, "contact:$i:id");
-              if ($related_cid && $related_cid != $old_related_cid) {
-                $data[] = [
-                  'fid' => $fid,
-                  'val' => $related_cid,
-                  'display' => wf_crm_contact_access($related_component,  wf_crm_search_filters($this->node, $related_component), $related_cid),
-                ];
+              $display = '';
+              if ($related_cid) {
+                $display = wf_crm_contact_access($related_component,  wf_crm_search_filters($this->node, $related_component), $related_cid);
               }
+
+              $data[] = [
+                'fid' => $fid,
+                'val' => $related_cid,
+                'display' => $display,
+              ];
             }
           }
         }


### PR DESCRIPTION
## Before

1- Create a webform with two contacts (can be replicated with more than two contacts too), and make sure "existing contact" is selected on both of them:

![2022-09-16 19_52_47-test _ cc139](https://user-images.githubusercontent.com/6275540/190710939-11cc6c67-969a-4c2f-b73a-1c6cb9f4a304.png)


2- Go to the "webform" tab, and edit the "existing contact" field for the first contact:
![2022-09-16 19_55_05-test _ cc139](https://user-images.githubusercontent.com/6275540/190711396-4fba7f7c-a90a-44a0-9244-9a413df37988.png)

make sure  "Form widget" is set to "Auto complete":
![2022-09-16 19_56_55-Edit component_ Existing Contact _ cc139](https://user-images.githubusercontent.com/6275540/190711524-8ad871dd-1997-4cc0-bb77-576a2dafe74b.png)

3- Do the same for the second contact, but also "default value" section, set "Set default contact from" to `Relationship to..`, "Relationship to Contact" set to `Contact 1` and specify any relationship you want under "Specify Relationship(s) *", in this example I set it to "Child of contact 1":

![2022-09-16 20_00_25-Edit component_ Existing Contact _ cc139](https://user-images.githubusercontent.com/6275540/190712050-f4953919-fe92-4fb0-965a-04088be95e1e.png)

3- Create two contacts in CiviCRM, and create a relationship between that match the relationship configured in step 3 above:

![image](https://user-images.githubusercontent.com/6275540/190712262-5d29cd8a-ac2a-41ef-af39-d54f3a57c68f.png)

4- Create a third contact in CiviCRM that have no any relationship.

5- Go to the webform itself, select the first contact you created under Contact 1 "existing contact", you will see that Contact 2 will get filled automatically because of the relationship between them.

Now if you selected the third contact in CiviCRM which has no relationships under Contact 1, Contact 2 part in the webform will remain unchanged. 


![2222222](https://user-images.githubusercontent.com/6275540/190713059-2055e38e-1ff3-446f-9329-b9e06cf4b762.gif)

What should happen here is that Contact 2 data should be cleared when the contact with no relationship got selected. 


## After
After repeating the steps above, Contact 2 data is cleared when a contact with no relationship is selected under Contact 1:
![11111](https://user-images.githubusercontent.com/6275540/190712590-329875c0-2ac4-4611-a82c-6227613ef2b5.gif)


## Notes
1- Ideally clicking on the "x" here should also clear the related field (if it is related to it in some relationship as it is in this case), but  solving it is a  more complicated and time consuming problem, thus I think it is more wiser to ignore it (unless there is a real need for it to be resolved).
![2022-09-16 20_11_14-Settings](https://user-images.githubusercontent.com/6275540/190713585-f97fc02c-df2f-41b1-8848-dbaf1d23f44b.png)

2- I did not send a PR to the main webform_civicrm repo, given it requires testing on Drupal 8 (and I guess 9 too) stack, which we don't have or use.

## Technical Details

This if statement:

```
if ($related_cid && $related_cid != $old_related_cid) {
```
and specifically this part `if ($related_cid ` Ignores related contact fields if no related contact was found, which is fine if you are filling the contact for the first time, but if you decided to change the contact then it causes the issue we have here, given that it will not return any field-key-value pair for such field, thus it value will remain the same. 

There does not seem to be any deep reason for having this if statement, given it was added here:
https://github.com/colemanw/webform_civicrm/pull/52/files
6 years ago as part of the feature to allow auto populating contacts, so a case like the one we have  here was  most likely wasn't thought much of, Thus here I am just removing it, removing it will result in returning the field-kay-value pair for the related contact field, but only the "value" will be empty when a contact with no relationship is selected, thus solving the issue we have here.