### PR TITLE
CIVIPLUS-983: Remove doTransferCheckout

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1992,37 +1992,34 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       $paymentProcessor->setCancelUrl($this->getIpnRedirectUrl('cancel'));
     }
 
-    if (method_exists($paymentProcessor, 'doTransferCheckout')) {
-      //Paypal Express checkout
-      if(wf_crm_aval($_POST, 'credit_card_number') == 'express'){
-        try {
-          $params['button'] = 'express';
-          $params['component'] = 'contribute';
-          $result = $paymentProcessor->doPreApproval($params);
-            if (empty($result)) {
-            // This could happen, for example, when paypal looks at the button value & decides it is not paypal express.
-            return;
-          }
-        }
-        catch (\Civi\Payment\Exception\PaymentProcessorException $e) {
-          drupal_set_message(ts('Payment approval failed with message :') . $e->getMessage(),'error');
-          CRM_Utils_System::redirect($this->getIpnRedirectUrl('cancel'));
-        }
-        $preApprovalParams = $paymentProcessor->getPreApprovalDetails($result['pre_approval_parameters']);
-        $params = array_merge($params, $preApprovalParams);
-        if (!empty($result['redirect_url'])) {
-          CRM_Utils_System::redirect($result['redirect_url']);
+    //Paypal Express checkout
+    if (wf_crm_aval($_POST, 'credit_card_number') == 'express') {
+      try {
+        $params['button'] = 'express';
+        $params['component'] = 'contribute';
+        $result = $paymentProcessor->doPreApproval($params);
+        if (empty($result)) {
+          // This could happen, for example, when paypal looks at the button value & decides it is not paypal express.
+          return;
         }
       }
-      // doTransferCheckout is deprecated but some processors might still implement it.
-      // Somewhere around 4.6 it was replaced by doPayment as the method of choice,
-      // but to be safe still call it if it exists for now.
-      $paymentProcessor->doTransferCheckout($params, 'contribute');
+      catch (\Civi\Payment\Exception\PaymentProcessorException $e) {
+        drupal_set_message(ts('Payment approval failed with message: ') . $e->getMessage(),'error');
+        CRM_Utils_System::redirect($this->getIpnRedirectUrl('cancel'));
+      }
+      $preApprovalParams = $paymentProcessor->getPreApprovalDetails($result['pre_approval_parameters']);
+      $params = array_merge($params, $preApprovalParams);
+      if (!empty($result['redirect_url'])) {
+        CRM_Utils_System::redirect($result['redirect_url']);
+      }
     }
-    else {
+    try {
       $paymentProcessor->doPayment($params);
     }
-
+    catch (\Civi\Payment\Exception\PaymentProcessorException $e) {
+      drupal_set_message(ts('Payment approval failed with message: ') . $e->getMessage(),'error');
+      CRM_Utils_System::redirect($this->getIpnRedirectUrl('cancel'));
+    }
   }
 
   /**

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1992,27 +1992,6 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       $paymentProcessor->setCancelUrl($this->getIpnRedirectUrl('cancel'));
     }
 
-    //Paypal Express checkout
-    if (wf_crm_aval($_POST, 'credit_card_number') == 'express') {
-      try {
-        $params['button'] = 'express';
-        $params['component'] = 'contribute';
-        $result = $paymentProcessor->doPreApproval($params);
-        if (empty($result)) {
-          // This could happen, for example, when paypal looks at the button value & decides it is not paypal express.
-          return;
-        }
-      }
-      catch (\Civi\Payment\Exception\PaymentProcessorException $e) {
-        drupal_set_message(ts('Payment approval failed with message: ') . $e->getMessage(),'error');
-        CRM_Utils_System::redirect($this->getIpnRedirectUrl('cancel'));
-      }
-      $preApprovalParams = $paymentProcessor->getPreApprovalDetails($result['pre_approval_parameters']);
-      $params = array_merge($params, $preApprovalParams);
-      if (!empty($result['redirect_url'])) {
-        CRM_Utils_System::redirect($result['redirect_url']);
-      }
-    }
     try {
       $paymentProcessor->doPayment($params);
     }

--- a/webform_civicrm.info
+++ b/webform_civicrm.info
@@ -2,9 +2,9 @@ name = Webform CiviCRM Integration
 description = A powerful, flexible, user-friendly form builder for CiviCRM.
 core = 7.x
 package = CiviCRM
-version = 7.x-5.4-patch2
+version = 7.x-5.4-patch3
 php = 7.0
 dependencies[] = civicrm (>=5.12)
 dependencies[] = webform (>=4.19)
 dependencies[] = options_element
-; patch 2
+; patch 3


### PR DESCRIPTION
Overview
----------------------------------------
added pull request patch https://github.com/colemanw/webform_civicrm/pull/420

Before
----------------------------------------
For Stripe and other payment processors that extend  CiviCRM Core Payment class, their `doTransferCheckout` method is protected, but `method_exists` in general works on even protected and private methods, ending in in webform_civicrm trying to call it and failing.

After
----------------------------------------
After this change, it will not try to use the deprecated method and will use doPayment method properly.

Technical Details
----------------------------------------
copied from PR https://github.com/colemanw/webform_civicrm/pull/420
