### PR TITLE
CIWEMB-209: Fix webform submission errors under certain contribution configurations

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -2180,6 +2180,25 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
           }
         }
       }
+      else {
+        // sets price field and price field value for non membership line items.
+        $priceFieldID = wf_civicrm_api('PriceField', 'get', [
+            'sequential' => 1,
+            'price_set_id' => 'default_contribution_amount',
+            'options' => ['limit' => 1],
+          ])['id'] ?? NULL;
+        $item['price_field_id'] = $priceFieldID;
+
+        if (!empty($priceFieldID)) {
+          $priceFieldValueID = wf_civicrm_api('PriceFieldValue', 'get', [
+              'sequential' => 1,
+              'price_field_id' => $priceFieldID,
+              'options' => ['limit' => 1],
+            ])['id'] ?? NULL;
+
+          $item['price_field_value_id'] = $priceFieldValueID;
+        }
+      }
 
       // Save the line_item
       $line_result = wf_civicrm_api('line_item', 'create', $item);


### PR DESCRIPTION
Overview
----------------------------------------

Fixing an error that occurs when submitting a webform with a configured contribution on the webform but without memberships. The error occurs when the "Email Receipt to Contributor" is set to True on the contribution page that is linked to the webform:

![2023-03-26 16_59_00-Title and Settings (Compuclient default contribution page) _ compuclientv2ssp](https://user-images.githubusercontent.com/6275540/227780900-0093d8a8-7ef8-423f-80a9-767296373e67.png)

 The fix ensures that submitting the webform with the above configuration works correctly. However, as a side effect, configuring "additional line items" on a webform is now broken.


Before
----------------------------------------
Submitting a webform with the configuration mentioned in the "overview" section throws an error.

After
----------------------------------------
- Submitting a webform with the configuration mentioned in the "overview" section works fine.
- However, configuring "additional line items" on a webform is now broken. The technical details of the fix and the reasons for this are discussed below.
![2023-03-26 17_03_24-test2 _ compuclientv2ssp](https://user-images.githubusercontent.com/6275540/227781086-358f77b3-07cd-4c64-9a94-775612562c46.png)


Technical Details
----------------------------------------

The error that occurs when submitting a webform with the above configuration is:

```
[Symfony\Component\Debug\Exception\FatalThrowableError]                                                
  Type error: Argument 1 passed to CRM_Financial_BAO_Order::setPriceSetID() must be of the type int, null given, called in /var/www/powerbase/sites/all/modules/civicrm/CRM/Financial/BAO/Order.php on line   
  905 
```

This error has been reported twice before at:

- https://lab.civicrm.org/dev/core/-/issues/3150
- https://www.drupal.org/project/webform_civicrm/issues/3236621

And fixed here:

- For Drupal 7:  https://github.com/colemanw/webform_civicrm/pull/621/files
- For Drupal 8: https://github.com/colemanw/webform_civicrm/pull/620/files

The fix in this pull request is similar to the ones mentioned above, but with some differences. The reasons why my fix has some differences and why the error here occurs in the first place are:

 - CiviCRM assumes that each line item should have a price_field_id and a price_field_value_id.
- But CiviCRM does not have any validation or database constraints to ensure that these fields cannot be set to NUL.
- And The webform_civicrm module never sets these two fields for any non-membership line item it creates, This is not something new, and has been the case since the module was created. Where membership line items will by default get these two fields populated because each membership type in CiviCRM is by default linked to a price field and price field value that CiviCRM creates automatically for each Membership Type.
- CiviCRM did not complain about this until versions > 5.45, due to changes in CiviCRM core, where it looks for "price_field_id" field, mainly when the Order API is used with the "send confirmation email" option.

- The PR that was submitted to the main webform_civicrm module fixes the issue by:

1- Defaulting the price_field_id to the default CiviCRM core price field which is called "default_contribution_amount" , and that is part of the default CiviCRM core price set "default_contribution_amount", which CiviCRM core even uses for contributions created in CiviCRM itself if no "Price Set" was selected when a user creates a contribution.

2- Defaulting membership line items price_field_id  to the "default_membership_type_amount" price field which is also part of a a price set with the same name. 

Though there are some problems with that PR:

1- It only sets the price_field_id field, not the price_field_value_id field, and while doing so seems to be enough to fix the issue, both price_field_id  and price_field_value_id are meant to be set on any line item, so keeping the price_field_value_id empty might result in errors or weird bugs in the future that might be hard to discover.

2- This fix also force membership line items to use the "default membership amount" price set/field, but that is not correct for membership line items given  their price_field_id and price_field_value_id should be coming from the membership type itself, and because they are already get populated correctly for membership line items without the need to do anything extra for them.

The fix in this PR addresses the above issues by:

1- Ensuring that both "price_field_id" and "price_field_value_id" are set. The "price_field_value_id" is set to the first price field value on the "default_contribution_amount", similar to how CiviCRM core sets these two fields for contributions created without using the price set option.

2- Ignoring the part that sets these two fields for membership line items because they are already set correctly without the need for any extra work.


### The "additional line items" problem

My PR here despite being more accurate than the original webform_civicrm PR above, it introduces new problem , the "additional line items" feature that the webform_civicrm module provides under the "Contribution" tab is no longer working (basically an error is thrown when you submit a webform with additional line items), this happens because the civicrm_line_item table has the following composite unique key (entity_id, entity_table, contribution_id, price_field_value_id, price_field_id), which means that both "price_field_value_id" and "price_field_id" can only be used by a single line item on any given contribution, so any new line item we create should use different price_field_id and price_field_value_id than any other line item that exists on the contribution.

This issue does not happen with the original PR submitted to the webform_civicrm module, because it does not set the "price_field_value_id" and just keeps it set to NULL, so the composite unique key won't apply to such line items.

Though I am personally fine with this, the webform "additional line items" feature does not seem to be well thought, it is not aligned with how CiviCRM core allows you to create a contribution with more than one line item, which is only possible in core by using "Price Sets" (which forces you to have unique price_field and price_field_value for each line item), and instead the webform_civicrm module just asks you to select the "financial type" for the line item you want to add, which is apparently not enough. A proper implementation for "additional line items" feature would require incorporating price sets, price field and price field values in the webform UI in some way for it work correctly, which is a bigger work, and something we (at Compuco) will need to discuss in case it is something needed for our use cases or not.