### PR TITLE
CIVIIB-107: HTML code showing on update my details page

### DIFF
--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -711,7 +711,7 @@ function wf_crm_contact_search($node, $component, $params, $contacts, $str = NUL
     }
     if (count($ret) < $limit && $component['extra']['allow_create']) {
       // HTML hack to get prompt to show up different than search results
-      $ret[] = ['id' => "-$str", 'name' => '<em><i>' . filter_xss($component['extra']['none_prompt']) . '</i></em>'];
+      $ret[] = ['id' => "-$str", 'name' => filter_xss($component['extra']['none_prompt'])];
     }
   }
   // Select results

--- a/includes/wf_crm_webform_ajax.inc
+++ b/includes/wf_crm_webform_ajax.inc
@@ -85,7 +85,7 @@ class wf_crm_webform_ajax extends wf_crm_webform_base {
       if ($_GET['load'] == 'name') {
         if ($_GET['cid'][0] === '-') {
           // HTML hack to get prompt to show up different than search results
-          $data = '<em><i>' . filter_xss($component['extra']['none_prompt']) . '</i></em>';
+          $data = filter_xss($component['extra']['none_prompt']);
         }
         else {
           $data = $name;


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes the issue of HTML code showing on the update my details page organization name field

Before
----------------------------------------
<img width="1417" alt="Screenshot 2023-05-01 at 4 41 49 PM" src="https://user-images.githubusercontent.com/126798502/235451679-7d579ade-e62d-4042-a073-e33b75c072e8.png">


After
----------------------------------------
<img width="1417" alt="Screenshot 2023-05-01 at 4 41 21 PM" src="https://user-images.githubusercontent.com/126798502/235451717-b8683d9e-1641-4f1e-82de-aec5ed692887.png">

Technical Details
----------------------------------------
Removed static HTML from the string to fix the issue.
