### PR TITLE
CST-231: Introduce read-only fields as alternative to disabled fields

### DIFF
--- a/css/webform_civicrm_forms.css
+++ b/css/webform_civicrm_forms.css
@@ -20,3 +20,8 @@
 #wf-crm-billing-items td + td {
   text-align: right;
 }
+
+form.webform-client-form input:read-only {
+  background-color: rgb(245 245 245);
+  border-color: #ccc;
+}

--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -167,7 +167,7 @@ function _webform_edit_civicrm_contact($component) {
     '#type' => 'select',
     '#multiple' => TRUE,
     '#title' => t('Fields to Lock'),
-    '#description' => t('Prevent editing by disabling or hiding fields when a contact already exists.'),
+    '#description' => t('Prevent editing by disabling, hiding, or setting fields to read-only when a contact already exists.'),
     '#default_value' => $component['extra']['hide_fields'],
     '#options' => ['' => '- ' . t('None') . ' -'] + wf_crm_contact_fields($node, $c),
     '#parents' => ['extra', 'hide_fields'],
@@ -176,7 +176,7 @@ function _webform_edit_civicrm_contact($component) {
     '#type' => 'select',
     '#title' => t('Locked fields should be'),
     '#default_value' => $component['extra']['hide_method'],
-    '#options' => ['hide' => t('Hidden'), 'disable' => t('Disabled')],
+    '#options' => ['hide' => t('Hidden'), 'disable' => t('Disabled'), 'readonly' => t('Read-only')],
     '#parents' => ['extra', 'hide_method'],
   ];
   $form['field_handling']['no_hide_blank'] = [

--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -156,8 +156,16 @@ var wfCivi = (function ($, D) {
         var type = (n[6] === 'name') ? 'name' : n[4];
         if ($.inArray(type, toHide) >= 0) {
           var fn = (op === 'hide' && (!showEmpty || !isFormItemBlank($el))) ? 'hide' : 'show';
-          $(':input', $el).webformProp('disabled', fn === 'hide');
-          $(':input', $el).webformProp('readonly', fn === 'hide');
+          switch (hideOrDisable) {
+            case 'disable':
+            case 'hide':
+              $(':input', $el).webformProp('disabled', fn === 'hide');
+              $(':input', $el).webformProp('readonly', fn === 'hide');
+              break;
+            case 'readonly':
+              $(':input', $el).webformProp('readonly', fn === 'hide');
+              break;
+          }
           $('select.civicrm-enabled[name*="_address_state_province_id"]').each(function() {
             $(this).webformProp('disabled', fn === 'hide');
             $(this).webformProp('readonly', fn === 'hide');


### PR DESCRIPTION
## Before
----------------------------------------

1- Create a webform and in the CiviCRM tab add one contact, enable "Existing Contact" and some other fields like "First and Last name" or maybe the "Organization Name" if you added a contact of type "Organization".

![2023-08-10 17_06_11-testlocked _ compuclient22sspv3](https://github.com/compucorp/webform_civicrm/assets/6275540/840e2ff5-c77e-4956-8013-f05419a0f08d)


2- From the "Webform -> Form components" tab, make the "Name" field required:

![2023-08-10 17_13_27-testlocked _ compuclient22sspv3](https://github.com/compucorp/webform_civicrm/assets/6275540/524023eb-8eac-42de-86b9-f28a387d33b5)

3- Then edit the "Existing Contact" field:

![2023-08-10 17_14_12-testlocked _ compuclient22sspv3](https://github.com/compucorp/webform_civicrm/assets/6275540/84136cce-8b6d-4bec-9ece-b0c029c9f517)


Then scroll down and:
- make the "name" field "locked":
- Set "Locked fields should be" to -> "Disabled"
- Enable "Submit disabled field value(s)" 

![2023-08-10 17_14_56-Edit component_ Existing Contact _ compuclient22sspv3](https://github.com/compucorp/webform_civicrm/assets/6275540/17448497-49d2-40dc-a55c-cfeec515fca5)


3- Now try to submit the webform by selecting an "Existing Contact" , make sure the contact you are selecting has a name for fields prefilling to work, now the moment you click on the submit button, an error complaining about missing "name" will appear:

![233232](https://github.com/compucorp/webform_civicrm/assets/6275540/376866ab-9326-434e-a1c2-d8d3a8e29255)


The reason I marked the "Name" field as required above is to show how the value of this field is not getting submitted to the server, but also even non required fields will not be submitted. Also other type of fields like phones or addresses suffer from the same problem if they were marked to be locked.


## After
----------------------------------------
New option for "Locked" fields can be used which is "Readyonly": 

![2023-08-10 17_39_14-Edit component_ Existing Contact _ compuclient22sspv3](https://github.com/compucorp/webform_civicrm/assets/6275540/a983a612-e27f-4b76-a1ba-fe13a2944d24)


Which should be used instead of "Disabled" option:

![22222](https://github.com/compucorp/webform_civicrm/assets/6275540/697f7e81-9479-4873-813d-ff0dc9e0fa18)




## Technical Details
----------------------------------------

Most browser (following the HTML standard) skip submitting disabled fields to the server, and can only be submitted if there is some JS code that intercept the form submission to include such fields, and while there is a setting on the webform_civiCRM module that is supposedly achieve that "Submit disabled field value(s)" which was added here:

https://github.com/colemanw/webform_civicrm/pull/97

I was not able to get it to work (even when I reverted my current webform version to older one (7.x-4.24)), and tbh when I look at the PR above that is supposedly allow submitting disabled fields, I am not sure if it ever worked, given all the code in that PR is purely on the backend, but allowing disabled fields to get submitted requires some JS code as I mentioned above to intercept the form submission, but I could not find any JS code in either webform_civicrm or webform modules that allow disabled fields to get submitted, so again I am not sure if it ever worked.

So to solve this problem I was between two options:

1- Adding a JS code to this module that temporarily mark disabled fields to be non disabled at the moment of the form submission, this can be achieved by adding this code:

```
  $('form').submit(function (e) {
    $('input:disabled, select:disabled').each(function () {
      $(this).removeAttr('disabled');
    });
  });
```

to  the `js/webform_civicrm_forms.js` .


2- Or by going with the approach mentioned in this PR: https://github.com/colemanw/webform_civicrm/pull/50 
which basically allows locked fields to be "Readonly" instead of either "Hidden" or "Disabled".

Readonly fields are submitted normally by all browsers unlike disabled ones, and they cannot be edited, but their main problem is that they cannot be visually distinguished from normal fields.


In my fix here I went with the  2nd approach, because I want to limit the effect of my changes, the JS code that I will add If I go with the first approach will apply to all webforms, and it is hard to predict if it will have unforeseen impact under certain webform configurations. 

But given there is a still the problem of the look of Readonly fields compared to Disabled ones, I've added a CSS class that make Readonly fields look as if they are disabled.
