### PR TITLE
FOSFA-232: Preserve the default value for date component

### DIFF
--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -521,7 +521,7 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
             }
             // Set value for "secure value" elements
             elseif ($element['#type'] == 'value') {
-              $element['#value'] = $val;
+              $element['#value'] = ($component['type'] !== 'hidden') ? $val : $element['#value'];
             }
             // Set default value
             else {

--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -501,6 +501,11 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
                 $val = array_pop($val);
               }
             }
+            if ($component['type'] == 'date') {
+              if (empty($val) && !empty($element['#default_value'])) {
+                $val = $element['#default_value'];
+              }
+            }
             if ($component['type'] == 'autocomplete' && is_string($val) && strlen($val)) {
               $options = wf_crm_field_options($component, '', $this->data);
               $val = wf_crm_aval($options, $val);


### PR DESCRIPTION
Overview
----------------------------------------

1. This pull request addresses an issue with the Date component in the CiviCRM Webform. When we add a CiviCRM date field to the form and configure that date field to have a 'Default value,' it does not consider the 'Default value' when displaying the webform. Instead, it always overrides it with the value from the CRM. For example, if we add the 'Birth Date' field from CiviCRM contact to the webform and set 'today' as the default value, it does not update the form with today's date values. Instead, it overrides it with the contact's birth date value, even if that value doesn't exist.

Before
----------------------------------------
![date_issue_before](https://github.com/compucorp/webform_civicrm/assets/2689257/72550a04-36be-48a2-93dd-7f18b3e81396)

After
----------------------------------------
![date_issue_after](https://github.com/compucorp/webform_civicrm/assets/2689257/e8816e1a-5240-46ab-9c40-133d4e6533fa)

Technical Details
----------------------------------------

- To address this issue, we have added an additional check for the 'date' component. It checks if the value from the CRM is empty, and if we have set a default value for that field in the webform, we will preserve it as the default value.


--------------------------------------------------------

2. Secondly, if we have a webform component marked as a 'hidden' type and have added a default value to be set for that component, so that once we submit this webform, it should sync that default value back to CiviCRM. However, currently, it's updating the value to be empty.

Before
----------------------------------------
https://github.com/compucorp/webform_civicrm/assets/2689257/6c4f3b61-624f-4605-9060-48725c36c74b

After
----------------------------------------
![arbitration_option_type_issue](https://github.com/compucorp/webform_civicrm/assets/2689257/c54baf51-fb6a-4fc8-b761-22c8e95b4f6d)

Technical Details
----------------------------------------

- To address this issue, we are checking if the element is hidden and then assigning the correct value that was set by default in the component field settings.
- 
![2023-11-28_13-16](https://github.com/compucorp/webform_civicrm/assets/2689257/99ac9e56-6a14-4365-94e2-a822d67c51f3)

