### PR TITLE
MMB-240: Add new field to choose contact for contribution

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -1104,6 +1104,13 @@ function wf_crm_get_fields($var = 'fields') {
         'name' => t('Contribution Source'),
         'type' => 'textfield',
       ];
+      $fields['contribution_contribution_contact_id'] = [
+        'name' => t('Contribution Contact'),
+        'type' => 'select',
+        'expose_list' => TRUE,
+        'default' => 1,
+        'data_type' => 'ContactReference',
+      ];
       // Line items
       $fields['contribution_line_total'] = [
           'name' => t('Line Item Amount'),

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -94,6 +94,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         if ($this->isLivePaymentProcessor() && $this->isPaymentPage() && !form_get_errors()) {
           if ($this->validateBillingFields()) {
             if ($this->createBillingContact()) {
+              $this->createLiveContributionContact();
               $this->submitLivePayment();
             }
           }
@@ -563,6 +564,28 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       }
     }
     return TRUE;
+  }
+
+  /**
+   * Create new contact in case of live payment.
+   * This will be useful in contributionParams method to assign
+   *  correct contribution contact.
+   * @return int
+   */
+  private function createLiveContributionContact() {
+    $cc = $this->data['contribution'][1]['contribution'][1]['contribution_contact_id'];
+    $ccid = $this->ent['contact'][$cc]['id'];
+    if (empty($ccid)) {
+      $contact = $this->data['contact'][$cc];
+      $ccid = $this->findDuplicateContact($contact);
+      // Create new contact if empty.
+      if (empty($ccid)) {
+        $email = $contact['email'][1];
+        $ccid = $email['contact_id'] = $this->createContact($contact);
+        wf_civicrm_api('email', 'create', $email);
+      }
+      $this->ent['contact'][$cc]['id'] = $ccid;
+    }
   }
 
   /**
@@ -1964,7 +1987,8 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $paymentProcessor = \Civi\Payment\System::singleton()->getById($params['payment_processor_id']);
 
     // Add contact details to params (most processors want a first_name and last_name)
-    $contact = wf_civicrm_api('contact', 'getsingle', ['id' => $this->ent['contact'][1]['id']]);
+    $contactId = $params['contact_id'] ?? $this->ent['contact'][1]['id'];
+    $contact = wf_civicrm_api('contact', 'getsingle', ['id' => $contactId]);
     $params += $contact;
     $params['contributionID'] = $params['id'] = $this->ent['contribution'][1]['id'];
 
@@ -2035,7 +2059,23 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $params['financial_type_id'] = $this->contribution_page['financial_type_id'];
     $params['currency'] = $params['currencyID'] = $this->contribution_page['currency'];
     $params['skipRecentView'] = $params['skipLineItem'] = 1;
-    $params['contact_id'] = $this->ent['contact'][1]['id'];
+    // Get contribution contact id.
+    $contribution_contact_id = $params['contribution_contact_id'];
+    // Set default contact 1 if contribution contact is empty.
+    // This is specifically added for user select option.
+    // If user do not choose any option from contribution contact field,
+    // then assign default contact 1 as contribution contact.
+    if (empty($contribution_contact_id)) {
+      $contribution_contact_cid = $this->ent['contact'][1]['id'];
+    }
+    // Pay later option, where payment processor is not selected.
+    elseif (empty($params['payment_processor_id'])) {
+      $contribution_contact_cid = $contribution_contact_id;
+    }
+    else {
+      $contribution_contact_cid = $this->ent['contact'][$contribution_contact_id]['id'];
+    }
+    $params['contact_id'] = $contribution_contact_cid;
     $params['total_amount'] = round($this->totalContribution, 2);
 
     // Most payment processors expect this (normally be set by contribution page processConfirm)

--- a/js/webform_civicrm_admin.js
+++ b/js/webform_civicrm_admin.js
@@ -536,21 +536,26 @@ var wfCiviAdmin = (function ($, D) {
         }
       });
 
+      var $contributionContact = $('[name=civicrm_1_contribution_1_contribution_contribution_contact_id]');
+
       function billingMessages() {
         var $pageSelect = $('[name=civicrm_1_contribution_1_contribution_contribution_page_id]');
+        var contributionContactVal = $.isNumeric($contributionContact.val()) ? $contributionContact.val() : 0;
         // Warning about contribution page with no email
-        if ($pageSelect.val() !== '0' && ($('[name=civicrm_1_contact_1_email_email]:checked').length < 1 || $('[name=contact_1_number_of_email]').val() == '0')) {
-          var msg = Drupal.t('You must enable an email field for !contact in order to process transactions.', {'!contact': getContactLabel(1)});
-          if (!$('.wf-crm-billing-email-alert').length) {
-            $pageSelect.after('<div class="messages error wf-crm-billing-email-alert">' + msg + ' <button>' + Drupal.t('Enable It') + '</button></div>');
-            $('.wf-crm-billing-email-alert button').click(function() {
-              $('input[name=civicrm_1_contact_1_email_email]').prop('checked', true).change();
-              $('select[name=contact_1_number_of_email]').val('1').change();
-              return false;
-            });
-            if ($('.wf-crm-billing-email-alert').is(':hidden')) {
-              billingEmailMsg = CRM.alert(msg, Drupal.t('Email Required'), 'error');
-            }
+        if (contributionContactVal && $pageSelect.val() !== '0' && ($(`[name=civicrm_${contributionContactVal}_contact_1_email_email]:checked`).length < 1 || $(`[name=contact_${contributionContactVal}_number_of_email]`).val() == '0')) {
+          var msg = Drupal.t('You must enable an email field for !contact in order to process transactions.', {'!contact': getContactLabel(contributionContactVal)});
+          // Remove older error message.
+          if ($('.wf-crm-billing-email-alert').length) {
+            $('.wf-crm-billing-email-alert').remove();
+          }
+          $pageSelect.after('<div class="messages error wf-crm-billing-email-alert">' + msg + ' <button>' + Drupal.t('Enable It') + '</button></div>');
+          $('.wf-crm-billing-email-alert button').click(function() {
+            $(`input[name=civicrm_${contributionContactVal}_contact_1_email_email]`).prop('checked', true).change();
+            $(`select[name=contact_${contributionContactVal}_number_of_email]`).val('1').change();
+            return false;
+          });
+          if ($('.wf-crm-billing-email-alert').is(':hidden')) {
+            billingEmailMsg = CRM.alert(msg, Drupal.t('Email Required'), 'error');
           }
         }
         else {
@@ -564,8 +569,41 @@ var wfCiviAdmin = (function ($, D) {
           $('#edit-participant').prepend('<div class="wf-crm-paid-entities-info messages status">' + Drupal.t('Configure the Contribution settings to enable paid events.') + '</div>');
         }
       }
-      $('[name=civicrm_1_contribution_1_contribution_contribution_page_id], [name=civicrm_1_contact_1_email_email]', context).once('email-alert').change(billingMessages);
+
+      // Contribution contact field error message handling for user select option.
+      function billingMessagesUserSelect() {
+        if ($contributionContact.val() === 'create_civicrm_webform_element') {
+          var $numberOfContacts = $('[name=number_of_contacts]').val();
+          var $pageSelect = $('[name=civicrm_1_contribution_1_contribution_contribution_page_id]');
+          // Process for all the selected contacts.
+          for (var c = $numberOfContacts; c >= 1; c--) {
+            if ($pageSelect.val() !== '0' && ($(`[name=civicrm_${c}_contact_1_email_email]:checked`).length < 1 || $(`[name=contact_${c}_number_of_email]`).val() == '0')) {
+              var msg = Drupal.t('You must enable an email field for !contact in order to process transactions.', {'!contact': getContactLabel(c)});
+              // Remove older error message.
+              if ($('.wf-crm-billing-email-alert-' + c).length) {
+                $('.wf-crm-billing-email-alert-' + c).remove();
+              }
+              $pageSelect.after('<div class="messages error wf-crm-billing-email-alert wf-crm-billing-email-alert-' + c + '">' + msg + ' <button data-contact="' + c + '">' + Drupal.t('Enable It') + '</button></div>');
+              $('.wf-crm-billing-email-alert-' + c + ' button').click(function() {
+                var contact = $(this).data('contact');
+                $(`input[name=civicrm_${contact}_contact_1_email_email]`).prop('checked', true).change();
+                $(`select[name=contact_${contact}_number_of_email]`).val('1').change();
+                $(this).parent().remove();
+                return false;
+              });
+            }
+            else {
+              $('.wf-crm-billing-email-alert-' + c).remove();
+            }
+          }
+        }
+      }
+
+      var contributionContactVal = $.isNumeric($contributionContact.val()) ? $contributionContact.val() : 1;
+      $(`[name=civicrm_1_contribution_1_contribution_contribution_page_id], [name=civicrm_${contributionContactVal}_contact_1_email_email], [name=civicrm_1_contribution_1_contribution_contribution_contact_id]`, context).once('email-alert').change(billingMessages);
+      $(`[name=civicrm_1_contribution_1_contribution_contribution_page_id], [name$=_contact_1_email_email], [name=civicrm_1_contribution_1_contribution_contribution_contact_id]`, context).once('email-alert-user-select').change(billingMessagesUserSelect);
       billingMessages();
+      billingMessagesUserSelect();
 
       // Handlers for submit-limit & tracking-mode mini-forms
       $('#configure-submit-limit', context).once('wf-civi').click(function() {


### PR DESCRIPTION
Overview
----------------------------------------
This PR aims to add new field to contribution section so that user specify which contact will be the contribution contact (i.e. the invoice will be addressed to).

Before
----------------------------------------
Default contact 1 is always passed.

After
----------------------------------------
Now user can have field to choose the required contact for contribution

![Screenshot 2023-11-17 at 5 21 10 PM](https://github.com/compucorp/webform_civicrm/assets/131177317/6f47b70c-dccc-407c-aa8e-98cfb9376907)

**Error message**
![Screenshot 2023-12-04 at 7 22 36 PM](https://github.com/compucorp/webform_civicrm/assets/131177317/0be8d5c6-92ed-4de6-bf2b-8ebc824d63f0)

**Error message for User select value**
![Screenshot 2023-12-06 at 6 33 59 PM](https://github.com/compucorp/webform_civicrm/assets/131177317/15bac444-607a-479a-a873-ff4f3f884870)



Technical Details
----------------------------------------
- Added Contribution Contact select list field to `wf_crm_get_fields`  method under `webform_civicrm/includes/utils.inc` file.
- Have data type for this new field as `ContactReference`, It will populate the list of contact selected.
- Added a logic to get the field value and pass it to contact ID param in `contributionParams()` method under the file - `webform_civicrm/includes/wf_crm_webform_postprocess.inc`.
- Have added the JS changes in `webform_civicrm/js/webform_civicrm_admin.js` to validate the email field enabled for other contacts.
- Created new function `billingMessagesUserSelect()` to handle the multiple error messages when Contribution contact field value is selected as `User select`
- Added new email param in `createContact` method to avoid duplicate contact creation.
