### PR TITLE
MMB-248: Allow other contacts to autoload the current user

### DIFF
--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -219,10 +219,10 @@ function _webform_edit_civicrm_contact($component) {
     '#default_value' => $component['extra']['default'],
     '#parents' => ['extra', 'default'],
   ];
-  if ($c == 1 && $contact_type == 'individual') {
+  if ($contact_type == 'individual') {
     $form['defaults']['default']['#options']['user'] = t('Current User');
   }
-  elseif ($c > 1) {
+  if ($c > 1) {
     $form['defaults']['default']['#options']['relationship'] = t('Relationship to...');
     $to = $component['extra']['default_relationship_to'];
     $form['defaults']['default_relationship_to'] = [

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -249,7 +249,7 @@ abstract class wf_crm_webform_base {
       switch ($component['extra']['default']) {
         case 'user':
           $cid = wf_crm_user_cid();
-          $found = ($c == 1 && $cid) ? [$cid] : [];
+          $found = ($cid) ? [$cid] : [];
           break;
         case 'contact_id':
           if ($component['extra']['default_contact_id']) {


### PR DESCRIPTION
Overview
----------------------------------------
This PR aims to add fix which allow contacts other than contact 1 on webform to autoload the current logged in user.

Before
----------------------------------------
Only contact 1 have option to select current user as default value.


https://github.com/compucorp/webform_civicrm/assets/131177317/e8ca7ede-f1b1-4759-9fc3-a7bc14441a15


After
----------------------------------------
Now contacts other than contact 1 have option to select current user as default value.

![Screenshot 2023-11-21 at 6 53 20 PM](https://github.com/compucorp/webform_civicrm/assets/131177317/bc0b8bc7-e560-4fde-9233-e417ba8554ff)

![Screenshot 2023-11-21 at 6 54 27 PM](https://github.com/compucorp/webform_civicrm/assets/131177317/37fd3e06-e45f-4f5a-860b-7f773b14f1dd)

Technical Details
----------------------------------------
- Alter the component `$form['defaults']['default']` from function `_webform_edit_civicrm_contact`.
- Remove the contact 1 condition from the below piece of code.
`if ($c == 1 && $contact_type == 'individual') {
  $form['defaults']['default']['#options']['user'] = t('Current User');
}`
Final code looks like this
`if ($contact_type == 'individual') {
  $form['defaults']['default']['#options']['user'] = t('Current User');
}`
- To pre fill the current user value make changes in `findContact` method under the file `webform_civicrm/includes/wf_crm_webform_base.inc`
`$found = ($cid) ? [$cid] : [];`
