### PR TITLE
ESEB-112: Don't assume that memberships with manualy entered dates are free

### DIFF
--- a/includes/wf_crm_admin_help.inc
+++ b/includes/wf_crm_admin_help.inc
@@ -304,7 +304,7 @@ class wf_crm_admin_help {
       '</p><p>' .
       t('Note: Number of terms is required to calculate membership fees for paid memberships.') .
       '</p><p>'.
-      t('If you choose to enter dates manually, enabling membership fee field will provide the price. Otherwise the membership will be free') .
+      t('If you choose to enter dates manually, enabling membership fee field will provide the price. Otherwise the price of one membership term will be used.') .
       '</p>';
   }
 

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1583,13 +1583,18 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
             $type = $item['membership_type_id'];
             $price = $this->getMembershipTypeField($type, 'minimum_fee');
 
-            //if number of terms is set, regard membership fee field as price per term
-            //if you choose to set dates manually while membership fee field is enabled, take the membership fee as total cost of this membership
             if (isset($item['fee_amount'])) {
               $price = $item['fee_amount'];
-              if (empty($item['num_terms'])) {
-                $item['num_terms'] = 1;
-              }
+            }
+
+            // 'Webform_civicrm' module default behaviour is assuming
+            // that if "Enter Dates Manually" option is selected
+            // then "Membership Fees" option should be enabled or otherwise
+            // the membership should be free.
+            // This is changed below so such memberships are no longer
+            // free and their price is the price of one membership term.
+            if (empty($item['num_terms'])) {
+              $item['num_terms'] = 1;
             }
 
             $membership_financialtype = $this->getMembershipTypeField($type, 'financial_type_id');


### PR DESCRIPTION
Before
----------------------------------------
If you configure a webform with:

- Number of Terms  =  "Enter dates manually" but with "Start date" not set.
- "Membership fee" is not set

And then submit the webform, the created membership will be free, meaning that no contribution will be created.

![2023-12-13 18_16_24-test _ Site-Install](https://github.com/compucorp/webform_civicrm/assets/6275540/8757c665-03be-4973-a89f-382c5ae73c04)


After
----------------------------------------
Submitting a webform with the above configurations will no longer assume that it is a free membership, and a contribution will be created instead using the full  membership price (or pro-rata price for fixed memberships).


Technical Details
----------------------------------------

"webform_civicrm" module and by default assumes that if you enable "Enter dates manually entered dates" then the membership will be a free membership, unless you also tick the "Membership fee" option, this is clear from the help message that is written here: https://github.com/compucorp/webform_civicrm/blob/79cb9b961e86804b531b7fb4fccd5cf8dd7a0b40/includes/wf_crm_admin_help.inc#L307

And while this behavior might be desirable for some organizations or people out there, it is not the case for our clients here at Compuco, and on top of that we sometimes want to apply pro-rata based on the selected start and end dates. 

In this PR: https://github.com/compucorp/webform_civicrm_membership_extras/pull/41 inside the `webform_civicrm_membership_extras` module we changed this default behavior so it sets the number of terms for such memberships to 1 (which means that the membership price will be the price of one membership term, of course unless it is a fixed membership then pro-rata will apply), but the problem with the approach in that PR (aside from being a bit complex code-wise), is that it assumes the "start date" should be included in the webform (the 'start date' checkbox should be ticked), but in some cases you don't want that, and instead you only want to set the end date to certain date but leave the start date empty (which means the start date will be set to today's date in such cases). 

So given that, I decided to go with a simpler approach where I removed the work that was done in that PR here: https://github.com/compucorp/webform_civicrm_membership_extras/pull/60
and instead I modified the code here in "webform_membership" module so it by default assumes the number of terms for the membership to be 1 if it is not set (which is the case if "Enter dates manually" option is selected").
