### PR TITLE
CSTMM-11: Apply our patches on top of webform_civicrm version 7.x-5.8

### DIFF
--- a/css/webform_civicrm_forms.css
+++ b/css/webform_civicrm_forms.css
@@ -20,3 +20,8 @@
 #wf-crm-billing-items td + td {
   text-align: right;
 }
+
+form.webform-client-form input:read-only {
+  background-color: rgb(245 245 245);
+  border-color: #ccc;
+}

--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -711,7 +711,7 @@ function wf_crm_contact_search($node, $component, $params, $contacts, $str = NUL
     }
     if (count($ret) < $limit && $component['extra']['allow_create']) {
       // HTML hack to get prompt to show up different than search results
-      $ret[] = ['id' => "-$str", 'name' => '<em><i>' . filter_xss($component['extra']['none_prompt']) . '</i></em>'];
+      $ret[] = ['id' => "-$str", 'name' => filter_xss($component['extra']['none_prompt'])];
     }
   }
   // Select results

--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -1036,6 +1036,7 @@ function wf_crm_find_case_roles($contact_a, $case, $case_role) {
     'relationship_type_id' => $case_role,
     'contact_id_a' => $contact_a,
     'case_id' => $case,
+    'is_active' => 1,
   ];
   $result = wf_civicrm_api('Relationship', 'get', $params);
   if (isset($result['values'][0]['contact_id_b'])) {

--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -167,7 +167,7 @@ function _webform_edit_civicrm_contact($component) {
     '#type' => 'select',
     '#multiple' => TRUE,
     '#title' => t('Fields to Lock'),
-    '#description' => t('Prevent editing by disabling or hiding fields when a contact already exists.'),
+    '#description' => t('Prevent editing by disabling, hiding, or setting fields to read-only when a contact already exists.'),
     '#default_value' => $component['extra']['hide_fields'],
     '#options' => ['' => '- ' . t('None') . ' -'] + wf_crm_contact_fields($node, $c),
     '#parents' => ['extra', 'hide_fields'],
@@ -176,7 +176,7 @@ function _webform_edit_civicrm_contact($component) {
     '#type' => 'select',
     '#title' => t('Locked fields should be'),
     '#default_value' => $component['extra']['hide_method'],
-    '#options' => ['hide' => t('Hidden'), 'disable' => t('Disabled')],
+    '#options' => ['hide' => t('Hidden'), 'disable' => t('Disabled'), 'readonly' => t('Read-only')],
     '#parents' => ['extra', 'hide_method'],
   ];
   $form['field_handling']['no_hide_blank'] = [

--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -219,10 +219,10 @@ function _webform_edit_civicrm_contact($component) {
     '#default_value' => $component['extra']['default'],
     '#parents' => ['extra', 'default'],
   ];
-  if ($c == 1 && $contact_type == 'individual') {
+  if ($contact_type == 'individual') {
     $form['defaults']['default']['#options']['user'] = t('Current User');
   }
-  elseif ($c > 1) {
+  if ($c > 1) {
     $form['defaults']['default']['#options']['relationship'] = t('Relationship to...');
     $to = $component['extra']['default_relationship_to'];
     $form['defaults']['default_relationship_to'] = [

--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -1115,6 +1115,13 @@ function wf_crm_get_fields($var = 'fields') {
         'name' => t('Contribution Source'),
         'type' => 'textfield',
       ];
+      $fields['contribution_contribution_contact_id'] = [
+        'name' => t('Contribution Contact'),
+        'type' => 'select',
+        'expose_list' => TRUE,
+        'default' => 1,
+        'data_type' => 'ContactReference',
+      ];
       // Line items
       $fields['contribution_line_total'] = [
           'name' => t('Line Item Amount'),

--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -75,6 +75,9 @@ function wf_crm_field_options($field, $context, $data) {
     elseif ($table == 'membership' && $name == 'num_terms') {
       $ret = drupal_map_assoc(range(1, 9));
     }
+    elseif ($table == 'membership' && $name == 'auto_renew') {
+      $ret = [1 => t('Yes'), 0 => t('No')];
+    }
     // Aside from the above special cases, most lists can be fetched from api.getoptions
     else {
       $params = ['field' => $name, 'context' => 'create'];
@@ -1245,6 +1248,12 @@ function wf_crm_get_fields($var = 'fields') {
       $fields['membership_end_date'] = [
         'name' => t('End Date'),
         'type' => 'date',
+      ];
+      $fields['membership_auto_renew'] = [
+        'name' => t('Auto-renew Membership?'),
+        'type' => 'select',
+        'expose_list' => TRUE,
+        'value' => 0,
       ];
     }
     // Add campaign fields

--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -1041,7 +1041,7 @@ class wf_crm_admin_form {
       '#type' => 'select',
       '#title' => t('Additional Line items'),
       '#default_value' => $num,
-      '#options' => range(0, 9),
+      '#options' => range(0, 49),
       '#prefix' => '<div class="number-of">',
       '#suffix' => '</div>',
     ];

--- a/includes/wf_crm_admin_help.inc
+++ b/includes/wf_crm_admin_help.inc
@@ -304,7 +304,7 @@ class wf_crm_admin_help {
       '</p><p>' .
       t('Note: Number of terms is required to calculate membership fees for paid memberships.') .
       '</p><p>'.
-      t('If you choose to enter dates manually, enabling membership fee field will provide the price. Otherwise the membership will be free') .
+      t('If you choose to enter dates manually, enabling membership fee field will provide the price. Otherwise the price of one membership term will be used.') .
       '</p>';
   }
 

--- a/includes/wf_crm_webform_ajax.inc
+++ b/includes/wf_crm_webform_ajax.inc
@@ -137,19 +137,21 @@ class wf_crm_webform_ajax extends wf_crm_webform_base {
           elseif ($i > $c && $field == 'existing') {
             $related_component = $this->getComponent($fid);
             if (wf_crm_aval($related_component['extra'], 'default') == 'relationship') {
-              $old_related_cid = wf_crm_aval($this->ent, "contact:$i:id");
               // Don't be fooled by old data
               $related_component['extra']['allow_url_autofill'] = FALSE;
               unset($this->ent['contact'][$i]);
               $this->findContact($related_component);
               $related_cid = wf_crm_aval($this->ent, "contact:$i:id");
-              if ($related_cid && $related_cid != $old_related_cid) {
-                $data[] = [
-                  'fid' => $fid,
-                  'val' => $related_cid,
-                  'display' => wf_crm_contact_access($related_component,  wf_crm_search_filters($this->node, $related_component), $related_cid),
-                ];
+              $display = '';
+              if ($related_cid) {
+                $display = wf_crm_contact_access($related_component,  wf_crm_search_filters($this->node, $related_component), $related_cid);
               }
+
+              $data[] = [
+                'fid' => $fid,
+                'val' => $related_cid,
+                'display' => $display,
+              ];
             }
           }
         }

--- a/includes/wf_crm_webform_ajax.inc
+++ b/includes/wf_crm_webform_ajax.inc
@@ -85,7 +85,7 @@ class wf_crm_webform_ajax extends wf_crm_webform_base {
       if ($_GET['load'] == 'name') {
         if ($_GET['cid'][0] === '-') {
           // HTML hack to get prompt to show up different than search results
-          $data = '<em><i>' . filter_xss($component['extra']['none_prompt']) . '</i></em>';
+          $data = filter_xss($component['extra']['none_prompt']);
         }
         else {
           $data = $name;

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -249,7 +249,7 @@ abstract class wf_crm_webform_base {
       switch ($component['extra']['default']) {
         case 'user':
           $cid = wf_crm_user_cid();
-          $found = ($c == 1 && $cid) ? [$cid] : [];
+          $found = ($cid) ? [$cid] : [];
           break;
         case 'contact_id':
           if ($component['extra']['default_contact_id']) {

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -2005,8 +2005,6 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $contact = wf_civicrm_api('contact', 'getsingle', ['id' => $this->ent['contact'][1]['id']]);
     $params += $contact;
     $params['contributionID'] = $params['id'] = $this->ent['contribution'][1]['id'];
-    // Generate a fake qfKey in case payment processor redirects to contribution thank-you page
-    $params['qfKey'] = $this->getQfKey();
 
     $params['contactID'] = $params['contact_id'];
     $params['currency'] = $params['currencyID'] = $this->contribution_page['currency'];

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -94,6 +94,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         if ($this->isLivePaymentProcessor() && $this->isPaymentPage() && !form_get_errors()) {
           if ($this->validateBillingFields()) {
             if ($this->createBillingContact()) {
+              $this->createLiveContributionContact();
               $this->submitLivePayment();
             }
           }
@@ -568,6 +569,27 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       }
     }
     return TRUE;
+  }
+
+  /**
+   * Create new contact in case of live payment.
+   * This will be useful in contributionParams method to assign
+   * correct contribution contact.
+   */
+  private function createLiveContributionContact() {
+    $cc = $this->data['contribution'][1]['contribution'][1]['contribution_contact_id'];
+    $ccid = $this->ent['contact'][$cc]['id'];
+    if (empty($ccid)) {
+      $contact = $this->data['contact'][$cc];
+      $ccid = $this->findDuplicateContact($contact);
+      // Create new contact if empty.
+      if (empty($ccid)) {
+        $email = $contact['email'][1];
+        $ccid = $email['contact_id'] = $this->createContact($contact);
+        wf_civicrm_api('email', 'create', $email);
+      }
+      $this->ent['contact'][$cc]['id'] = $ccid;
+    }
   }
 
   /**
@@ -2002,7 +2024,8 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $paymentProcessor = \Civi\Payment\System::singleton()->getById($params['payment_processor_id']);
 
     // Add contact details to params (most processors want a first_name and last_name)
-    $contact = wf_civicrm_api('contact', 'getsingle', ['id' => $this->ent['contact'][1]['id']]);
+    $contactId = $params['contact_id'] ?? $this->ent['contact'][1]['id'];
+    $contact = wf_civicrm_api('contact', 'getsingle', ['id' => $contactId]);
     $params += $contact;
     $params['contributionID'] = $params['id'] = $this->ent['contribution'][1]['id'];
 
@@ -2099,7 +2122,23 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $params['financial_type_id'] = $this->contribution_page['financial_type_id'];
     $params['currency'] = $params['currencyID'] = $this->contribution_page['currency'];
     $params['skipRecentView'] = $params['skipLineItem'] = 1;
-    $params['contact_id'] = $this->ent['contact'][1]['id'];
+    // Get contribution contact id.
+    $contribution_contact_id = $params['contribution_contact_id'];
+    // Set default contact 1 if contribution contact is empty.
+    // This is specifically added for user select option.
+    // If user do not choose any option from contribution contact field,
+    // then assign default contact 1 as contribution contact.
+    if (empty($contribution_contact_id)) {
+      $contribution_contact_cid = $this->ent['contact'][1]['id'];
+    }
+    // Pay later option, where payment processor is not selected.
+    elseif (empty($params['payment_processor_id'])) {
+      $contribution_contact_cid = $contribution_contact_id;
+    }
+    else {
+      $contribution_contact_cid = $this->ent['contact'][$contribution_contact_id]['id'];
+    }
+    $params['contact_id'] = $contribution_contact_cid;
     $params['total_amount'] = round($this->totalContribution, 2);
 
     // Most payment processors expect this (normally be set by contribution page processConfirm)

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -2254,7 +2254,9 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $contributionResult = CRM_Contribute_BAO_Contribution::getValues(['id' => $id], CRM_Core_DAO::$_nullArray, CRM_Core_DAO::$_nullArray);
 
     // Save line-items
+    $lineItemNumber = 0;
     foreach ($this->line_items as &$item) {
+      $lineItemNumber++;
       if (empty($item['line_total'])) {
         continue;
       }
@@ -2291,6 +2293,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         $priceFieldID = wf_civicrm_api('PriceField', 'get', [
           'sequential' => 1,
           'price_set_id' => 'default_contribution_amount',
+          'name' => 'webform_additional_line_item_' . $lineItemNumber,
           'options' => ['limit' => 1],
         ])['id'] ?? NULL;
         $item['price_field_id'] = $priceFieldID;

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1643,13 +1643,18 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
             $type = $item['membership_type_id'];
             $price = $this->getMembershipTypeField($type, 'minimum_fee');
 
-            //if number of terms is set, regard membership fee field as price per term
-            //if you choose to set dates manually while membership fee field is enabled, take the membership fee as total cost of this membership
             if (isset($item['fee_amount'])) {
               $price = $item['fee_amount'];
-              if (empty($item['num_terms'])) {
-                $item['num_terms'] = 1;
-              }
+            }
+
+            // 'Webform_civicrm' module default behaviour is assuming
+            // that if "Enter Dates Manually" option is selected
+            // then "Membership Fees" option should be enabled or otherwise
+            // the membership should be free.
+            // This is changed below so such memberships are no longer
+            // free and their price is the price of one membership term.
+            if (empty($item['num_terms'])) {
+              $item['num_terms'] = 1;
             }
 
             $membership_financialtype = $this->getMembershipTypeField($type, 'financial_type_id');

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1187,8 +1187,22 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       // The api won't let us manually set status without this weird param
       $params['skipStatusCal'] = !empty($params['status_id']);
 
-      if (isset($this->ent['contribution_recur'][1]['id'])) {
-        $params['contribution_recur_id'] = $this->ent['contribution_recur'][1]['id'];
+      /**
+       * If the webform configured with a recurring contribution
+       * and auto-renew for the membership set to True, then we
+       * set the membership contribution_recur_id field to
+       * point to the recurring contribution, since for a membership
+       * to be considered auto-renew in CiviCRM core, it should
+       * have both this field set to the related recurring contribution
+       * and for the related recurring contribution auto_renew field
+       * to be set to TRUE.
+       */
+      if (isset($this->ent['contribution_recur'][1]['id']) && !empty($params['auto_renew'])) {
+        $contributionRecurId = $this->ent['contribution_recur'][1]['id'];
+
+        $params['contribution_recur_id'] = $contributionRecurId;
+
+        unset($params['auto_renew']);
       }
 
       $result = wf_civicrm_api('membership', 'create', $params);
@@ -1814,7 +1828,12 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     // Only if #installments = 1, do we process a single transaction/contribution. #installments = 0 (or not set) in CiviCRM Core means open ended commitment;
     $numInstallments = wf_crm_aval($contributionParams, 'installments', NULL, TRUE);
     $frequencyInterval = wf_crm_aval($contributionParams, 'frequency_unit');
-    if ($numInstallments != 1 && !empty($frequencyInterval)) {
+    $isThereMembershipToBeAutoRenewed = $this->isThereMembershipToBeAutoRenewed();
+    if (($numInstallments != 1 || $isThereMembershipToBeAutoRenewed) && !empty($frequencyInterval)) {
+      if ($isThereMembershipToBeAutoRenewed) {
+        $contributionParams['auto_renew'] = 1;
+      }
+
       $result = $this->contributionRecur($contributionParams);
     }
     else {
@@ -1871,6 +1890,10 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       'payment_processor_id' =>  $contributionParams['payment_processor_id'],
       'financial_type_id' =>  $contributionParams['financial_type_id'],
     ];
+
+    if (!empty($contributionParams['auto_renew'])) {
+      $contributionRecurParams['auto_renew'] = 1;
+    }
 
     if(empty($contributionParams['payment_processor_id'])) {
       $contributionRecurParams['payment_processor_id'] = 'null';
@@ -1939,7 +1962,12 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
 
     $numInstallments = wf_crm_aval($params, 'installments', NULL, TRUE);
     $frequencyInterval = wf_crm_aval($params, 'frequency_unit');
-    if ($numInstallments != 1 && !empty($frequencyInterval) && $this->contributionIsPayLater) {
+    $isThereMembershipToBeAutoRenewed = $this->isThereMembershipToBeAutoRenewed();
+    if (($numInstallments != 1 || $isThereMembershipToBeAutoRenewed) && !empty($frequencyInterval)) {
+      if ($isThereMembershipToBeAutoRenewed) {
+        $params['auto_renew'] = 1;
+      }
+
       $result = $this->contributionRecur($params, 'deferred');
     }
     else {
@@ -1947,6 +1975,22 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     }
 
     $this->ent['contribution'][1]['id'] = $result['id'];
+  }
+
+  /**
+   * Determines if the webform is configured to have
+   * any membership to be auto-renewed or not.
+   */
+  private function isThereMembershipToBeAutoRenewed() {
+    $autoRenewMembership = FALSE;
+    foreach ($this->data['membership'] as $contactMemberships) {
+      foreach($contactMemberships['membership'] as $membership) {
+        if (!empty($membership['auto_renew'])) {
+          $autoRenewMembership = TRUE;
+        }
+      }
+    }
+    return $autoRenewMembership;
   }
 
   /**

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1845,7 +1845,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
    * This happens during form validation and sets a form error if unsuccessful
    */
   private function submitLivePayment() {
-    $contributionParams = $this->contributionParams();
+    $contributionParams = $this->contributionParams(TRUE);
 
     // Only if #installments = 1, do we process a single transaction/contribution. #installments = 0 (or not set) in CiviCRM Core means open ended commitment;
     $numInstallments = wf_crm_aval($contributionParams, 'installments', NULL, TRUE);
@@ -1978,7 +1978,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       }
     }
 
-    $params = $this->contributionParams();
+    $params = $this->contributionParams(FALSE);
     $params['contribution_status_id'] = 'Pending';
     $params['is_pay_later'] = $this->contributionIsPayLater;
 
@@ -2115,9 +2115,10 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
 
   /**
    * Format contribution params for transact/pay-later
+   * @param bool $isLivePayment
    * @return array
    */
-  private function contributionParams() {
+  private function contributionParams($isLivePayment) {
     $params = $this->billing_params + $this->data['contribution'][1]['contribution'][1];
     $params['financial_type_id'] = $this->contribution_page['financial_type_id'];
     $params['currency'] = $params['currencyID'] = $this->contribution_page['currency'];
@@ -2131,8 +2132,8 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     if (empty($contribution_contact_id)) {
       $contribution_contact_cid = $this->ent['contact'][1]['id'];
     }
-    // Pay later option, where payment processor is not selected.
-    elseif (empty($params['payment_processor_id'])) {
+    // Pay later option, where payment processor is not selected or non-live payment processor (like GoCardless).
+    elseif (empty($params['payment_processor_id']) || !$isLivePayment) {
       $contribution_contact_cid = $contribution_contact_id;
     }
     else {

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -2246,11 +2246,25 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
           }
         }
       }
-      $item['price_field_id'] = wf_civicrm_api('PriceField', 'get', [
-        'sequential' => 1,
-        'price_set_id' => $priceSetId,
-        'options' => ['limit' => 1],
-      ])['id'] ?? NULL;
+      else {
+        // sets price field and price field value for non membership line items.
+        $priceFieldID = wf_civicrm_api('PriceField', 'get', [
+          'sequential' => 1,
+          'price_set_id' => 'default_contribution_amount',
+          'options' => ['limit' => 1],
+        ])['id'] ?? NULL;
+        $item['price_field_id'] = $priceFieldID;
+
+        if (!empty($priceFieldID)) {
+          $priceFieldValueID = wf_civicrm_api('PriceFieldValue', 'get', [
+            'sequential' => 1,
+            'price_field_id' => $priceFieldID,
+            'options' => ['limit' => 1],
+          ])['id'] ?? NULL;
+
+          $item['price_field_value_id'] = $priceFieldValueID;
+        }
+      }
 
       // Save the line_item
       $line_result = wf_civicrm_api('line_item', 'create', $item);

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1227,6 +1227,15 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         unset($params['auto_renew']);
       }
 
+      // When the membership on the Webform is configured with "Enter Dates Manually" option
+      // then the "Number Of Terms" will be 0 (empty), but having the "Number Of terms" set to
+      // 0 prevent CiviCRM from calculating the membership dates correctly, specially the end
+      // date if it is not ticked on the membership configuration tab, and it might result
+      // in problems in other areas (like renewal).
+      if (empty($params['num_terms'])) {
+        $params['num_terms'] = 1;
+      }
+
       $result = wf_civicrm_api('membership', 'create', $params);
 
       if (!empty($result['id'])) {

--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -501,6 +501,11 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
                 $val = array_pop($val);
               }
             }
+            if ($component['type'] == 'date') {
+              if (empty($val) && !empty($element['#default_value'])) {
+                $val = $element['#default_value'];
+              }
+            }
             if ($component['type'] == 'autocomplete' && is_string($val) && strlen($val)) {
               $options = wf_crm_field_options($component, '', $this->data);
               $val = wf_crm_aval($options, $val);
@@ -516,7 +521,7 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
             }
             // Set value for "secure value" elements
             elseif ($element['#type'] == 'value') {
-              $element['#value'] = $val;
+              $element['#value'] = ($component['type'] !== 'hidden') ? $val : $element['#value'];
             }
             // Set default value
             else {

--- a/js/webform_civicrm_admin.js
+++ b/js/webform_civicrm_admin.js
@@ -513,6 +513,29 @@ var wfCiviAdmin = (function ($, D) {
         }
       }).change();
 
+      var autorenewMembershipsTracker = {};
+      var $membershipPageSelect = $('.form-item-membership-1-number-of-membership');
+      $('select[name$=_membership_auto_renew]').change(function(e, type) {
+        var fieldName = $(this).attr('name');
+        autorenewMembershipsTracker[fieldName] = $(this).val();
+
+        autorenew_counter = 0;
+        for(var key in autorenewMembershipsTracker){
+          if (autorenewMembershipsTracker[key] != 0) {
+            autorenew_counter++;
+          }
+        }
+
+        if (autorenew_counter > 1) {
+          if (!$('.wf-crm-membership-autorenew-alert').length) {
+            var msg = Drupal.t("Ensure that the memberships selected to be Auto-Renewed have the same frequency unit and interval or otherwise it might not work well !");
+            $membershipPageSelect.after('<div class="messages error wf-crm-membership-autorenew-alert">' + msg + '</div>');
+          }
+        } else {
+          $('.wf-crm-membership-autorenew-alert').remove();
+        }
+      });
+
       function billingMessages() {
         var $pageSelect = $('[name=civicrm_1_contribution_1_contribution_contribution_page_id]');
         // Warning about contribution page with no email

--- a/js/webform_civicrm_admin.js
+++ b/js/webform_civicrm_admin.js
@@ -536,21 +536,26 @@ var wfCiviAdmin = (function ($, D) {
         }
       });
 
+      var $contributionContact = $('[name=civicrm_1_contribution_1_contribution_contribution_contact_id]');
+
       function billingMessages() {
         var $pageSelect = $('[name=civicrm_1_contribution_1_contribution_contribution_page_id]');
+        var contributionContactVal = $.isNumeric($contributionContact.val()) ? $contributionContact.val() : 0;
         // Warning about contribution page with no email
-        if ($pageSelect.val() !== '0' && ($('[name=civicrm_1_contact_1_email_email]:checked').length < 1 || $('[name=contact_1_number_of_email]').val() == '0')) {
-          var msg = Drupal.t('You must enable an email field for !contact in order to process transactions.', {'!contact': getContactLabel(1)});
-          if (!$('.wf-crm-billing-email-alert').length) {
-            $pageSelect.after('<div class="messages error wf-crm-billing-email-alert">' + msg + ' <button>' + Drupal.t('Enable It') + '</button></div>');
-            $('.wf-crm-billing-email-alert button').click(function() {
-              $('input[name=civicrm_1_contact_1_email_email]').prop('checked', true).change();
-              $('select[name=contact_1_number_of_email]').val('1').change();
-              return false;
-            });
-            if ($('.wf-crm-billing-email-alert').is(':hidden')) {
-              billingEmailMsg = CRM.alert(msg, Drupal.t('Email Required'), 'error');
-            }
+        if (contributionContactVal && $pageSelect.val() !== '0' && ($(`[name=civicrm_${contributionContactVal}_contact_1_email_email]:checked`).length < 1 || $(`[name=contact_${contributionContactVal}_number_of_email]`).val() == '0')) {
+          var msg = Drupal.t('You must enable an email field for !contact in order to process transactions.', {'!contact': getContactLabel(contributionContactVal)});
+          // Remove older error message.
+          if ($('.wf-crm-billing-email-alert').length) {
+            $('.wf-crm-billing-email-alert').remove();
+          }
+          $pageSelect.after('<div class="messages error wf-crm-billing-email-alert">' + msg + ' <button>' + Drupal.t('Enable It') + '</button></div>');
+          $('.wf-crm-billing-email-alert button').click(function() {
+            $(`input[name=civicrm_${contributionContactVal}_contact_1_email_email]`).prop('checked', true).change();
+            $(`select[name=contact_${contributionContactVal}_number_of_email]`).val('1').change();
+            return false;
+          });
+          if ($('.wf-crm-billing-email-alert').is(':hidden')) {
+            billingEmailMsg = CRM.alert(msg, Drupal.t('Email Required'), 'error');
           }
         }
         else {
@@ -564,8 +569,41 @@ var wfCiviAdmin = (function ($, D) {
           $('#edit-participant').prepend('<div class="wf-crm-paid-entities-info messages status">' + Drupal.t('Configure the Contribution settings to enable paid events.') + '</div>');
         }
       }
-      $('[name=civicrm_1_contribution_1_contribution_contribution_page_id], [name=civicrm_1_contact_1_email_email]', context).once('email-alert').change(billingMessages);
+
+      // Contribution contact field error message handling for user select option.
+      function billingMessagesUserSelect() {
+        if ($contributionContact.val() === 'create_civicrm_webform_element') {
+          var $numberOfContacts = $('[name=number_of_contacts]').val();
+          var $pageSelect = $('[name=civicrm_1_contribution_1_contribution_contribution_page_id]');
+          // Process for all the selected contacts.
+          for (var c = $numberOfContacts; c >= 1; c--) {
+            if ($pageSelect.val() !== '0' && ($(`[name=civicrm_${c}_contact_1_email_email]:checked`).length < 1 || $(`[name=contact_${c}_number_of_email]`).val() == '0')) {
+              var msg = Drupal.t('You must enable an email field for !contact in order to process transactions.', {'!contact': getContactLabel(c)});
+              // Remove older error message.
+              if ($('.wf-crm-billing-email-alert-' + c).length) {
+                $('.wf-crm-billing-email-alert-' + c).remove();
+              }
+              $pageSelect.after('<div class="messages error wf-crm-billing-email-alert wf-crm-billing-email-alert-' + c + '">' + msg + ' <button data-contact="' + c + '">' + Drupal.t('Enable It') + '</button></div>');
+              $('.wf-crm-billing-email-alert-' + c + ' button').click(function() {
+                var contact = $(this).data('contact');
+                $(`input[name=civicrm_${contact}_contact_1_email_email]`).prop('checked', true).change();
+                $(`select[name=contact_${contact}_number_of_email]`).val('1').change();
+                $(this).parent().remove();
+                return false;
+              });
+            }
+            else {
+              $('.wf-crm-billing-email-alert-' + c).remove();
+            }
+          }
+        }
+      }
+
+      var contributionContactVal = $.isNumeric($contributionContact.val()) ? $contributionContact.val() : 1;
+      $(`[name=civicrm_1_contribution_1_contribution_contribution_page_id], [name=civicrm_${contributionContactVal}_contact_1_email_email], [name=civicrm_1_contribution_1_contribution_contribution_contact_id]`, context).once('email-alert').change(billingMessages);
+      $(`[name=civicrm_1_contribution_1_contribution_contribution_page_id], [name$=_contact_1_email_email], [name=civicrm_1_contribution_1_contribution_contribution_contact_id]`, context).once('email-alert-user-select').change(billingMessagesUserSelect);
       billingMessages();
+      billingMessagesUserSelect();
 
       // Handlers for submit-limit & tracking-mode mini-forms
       $('#configure-submit-limit', context).once('wf-civi').click(function() {

--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -156,8 +156,16 @@ var wfCivi = (function ($, D) {
         var type = (n[6] === 'name') ? 'name' : n[4];
         if ($.inArray(type, toHide) >= 0) {
           var fn = (op === 'hide' && (!showEmpty || !isFormItemBlank($el))) ? 'hide' : 'show';
-          $(':input', $el).webformProp('disabled', fn === 'hide');
-          $(':input', $el).webformProp('readonly', fn === 'hide');
+          switch (hideOrDisable) {
+            case 'disable':
+            case 'hide':
+              $(':input', $el).webformProp('disabled', fn === 'hide');
+              $(':input', $el).webformProp('readonly', fn === 'hide');
+              break;
+            case 'readonly':
+              $(':input', $el).webformProp('readonly', fn === 'hide');
+              break;
+          }
           $('select.civicrm-enabled[name*="_address_state_province_id"]').each(function() {
             $(this).webformProp('disabled', fn === 'hide');
             $(this).webformProp('readonly', fn === 'hide');

--- a/webform_civicrm.info
+++ b/webform_civicrm.info
@@ -6,3 +6,4 @@ php = 7.0
 dependencies[] = civicrm (>=5.12)
 dependencies[] = webform (>=4.19)
 dependencies[] = options_element
+; patch 1

--- a/webform_civicrm.install
+++ b/webform_civicrm.install
@@ -36,6 +36,13 @@ function webform_civicrm_requirements($phase) {
 }
 
 /**
+ * Implements hook_install().
+ */
+function webform_civicrm_install() {
+  _webform_civicrm_generatePriceFields(100);
+}
+
+/**
  * Implements hook_schema().
  */
 function webform_civicrm_schema() {
@@ -831,4 +838,52 @@ function webform_civicrm_update_7403() {
     'default' => 0,
   ];
   db_add_field('webform_civicrm_forms', 'create_new_relationship', $field);
+}
+
+function webform_civicrm_update_7404() {
+  _webform_civicrm_generatePriceFields(50);
+}
+
+/**
+ * Create "Price fields" for "additional line items" functionality.
+ */
+function _webform_civicrm_generatePriceFields($numberOfFieldsToCreate) {
+  civicrm_initialize();
+  $priceField = civicrm_api3('PriceField',
+    'getsingle',
+    [
+      'price_set_id' => civicrm_api3('PriceSet', 'getvalue', ['name' => 'default_contribution_amount', 'return' => 'id']),
+      'options' => ['limit' => 1],
+    ]
+  );
+  $priceFieldParams = $priceField;
+  unset($priceFieldParams['id'], $priceFieldParams['name'], $priceFieldParams['weight'], $priceFieldParams['is_required']);
+  $priceFieldValue = civicrm_api3('PriceFieldValue',
+    'getsingle',
+    [
+      'price_field_id' => $priceField['id'],
+      'options' => ['limit' => 1],
+    ]
+  );
+  $priceFieldValueParams = $priceFieldValue;
+  unset($priceFieldValueParams['id'], $priceFieldValueParams['name'], $priceFieldValueParams['weight']);
+  for ($i = 1; $i <= $numberOfFieldsToCreate; ++$i) {
+    $name = 'webform_additional_line_item_' . $i;
+    $params = array_merge($priceFieldParams, ['label' => ts('Webform Additional Line Item') . " $i", 'name' => $name]);
+    $priceField = civicrm_api3('PriceField', 'get', $params)['values'];
+    if (empty($priceField)) {
+      $p = civicrm_api3('PriceField', 'create', $params);
+      civicrm_api3('PriceFieldValue', 'create', array_merge(
+        $priceFieldValueParams,
+        [
+          'label' => ts('Webform Additional Item') . " $i",
+          'name' => $name,
+          'price_field_id' => $p['id'],
+        ]
+      ));
+    }
+    else {
+      civicrm_api3('PriceField', 'create', ['id' => key($priceField), 'is_active' => TRUE]);
+    }
+  }
 }


### PR DESCRIPTION
Overview
----------------------------------------
We decided to update Compuclient to use the latest webform_civicrm version, which is 7.x-5.8 at the moment. so here I created new branch  https://github.com/compucorp/webform_civicrm/tree/7.x-5.8-patches that is created from webform_civicrm version `7.x-5.8` , and then applied all of the patches we need to it, these patches are:


1- MAE-179: Adding memberships Auto-renewal support => https://github.com/colemanw/webform_civicrm/pull/274
2- MAE-179: Improving autorenewal user experience => https://github.com/colemanw/webform_civicrm/pull/275
3- ASESPRT-390: Fix Sagepay payment processor payments => https://github.com/compucorp/webform_civicrm/pull/34
4- CATL-2102: Filter to get active relationships => https://github.com/compucorp/webform_civicrm/pull/30
5- CATL-2264: Clear in-relation contact reference when other contact with no relationship is selected => https://github.com/compucorp/webform_civicrm/pull/42
6- CIWEMB-209: Fix webform submission errors for certain contribution configurations => https://github.com/compucorp/webform_civicrm/pull/44
7- CIVIIB-107: Fix HTML code showing on update my details page => https://github.com/compucorp/webform_civicrm/pull/46
8- FOSFA-232: Preserve the default value for date component => https://github.com/compucorp/webform_civicrm/pull/49
9- MMB-248: Allow other contacts to autoload the current => https://github.com/compucorp/webform_civicrm/pull/51
10- CST-231: Introduce read-only fields as alternative to disabled fields => https://github.com/compucorp/webform_civicrm/pull/48

There are also these two patches,  but I did not have to apply them given they are now both part of webform_civicrm version  `7.x-5.8` :

- https://github.com/compucorp/webform_civicrm/pull/32
- https://github.com/compucorp/webform_civicrm/pull/43


Also the following extra patches that are not part of the old patched version are added:

- MMB-240: Add new field to choose contact for contribution => https://github.com/compucorp/webform_civicrm/pull/50 and this follow up fix for it: https://github.com/compucorp/webform_civicrm/pull/54
- PROD-122: Add proper support for additional line items feature (Follow up fix for CIWEMB-209)=> https://github.com/compucorp/webform_civicrm/pull/55
- ESEB-112: Don't assume that memberships with manually entered dates are free => https://github.com/compucorp/webform_civicrm/pull/52 + https://github.com/compucorp/webform_civicrm/pull/56