### PR TITLE
CSTMM-11: Fix an error when submitting webforms when GoCardless is set as payment processor

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1845,7 +1845,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
    * This happens during form validation and sets a form error if unsuccessful
    */
   private function submitLivePayment() {
-    $contributionParams = $this->contributionParams();
+    $contributionParams = $this->contributionParams(TRUE);
 
     // Only if #installments = 1, do we process a single transaction/contribution. #installments = 0 (or not set) in CiviCRM Core means open ended commitment;
     $numInstallments = wf_crm_aval($contributionParams, 'installments', NULL, TRUE);
@@ -1978,7 +1978,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       }
     }
 
-    $params = $this->contributionParams();
+    $params = $this->contributionParams(FALSE);
     $params['contribution_status_id'] = 'Pending';
     $params['is_pay_later'] = $this->contributionIsPayLater;
 
@@ -2115,9 +2115,10 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
 
   /**
    * Format contribution params for transact/pay-later
+   * @param bool $isLivePayment
    * @return array
    */
-  private function contributionParams() {
+  private function contributionParams($isLivePayment) {
     $params = $this->billing_params + $this->data['contribution'][1]['contribution'][1];
     $params['financial_type_id'] = $this->contribution_page['financial_type_id'];
     $params['currency'] = $params['currencyID'] = $this->contribution_page['currency'];
@@ -2131,8 +2132,8 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     if (empty($contribution_contact_id)) {
       $contribution_contact_cid = $this->ent['contact'][1]['id'];
     }
-    // Pay later option, where payment processor is not selected.
-    elseif (empty($params['payment_processor_id'])) {
+    // Pay later option, where payment processor is not selected or non-live payment processor (like GoCardless).
+    elseif (empty($params['payment_processor_id']) || !$isLivePayment) {
       $contribution_contact_cid = $contribution_contact_id;
     }
     else {


### PR DESCRIPTION
Overview
----------------------------------------
In this PR: https://github.com/compucorp/webform_civicrm/pull/50 the ability to change the contribution contact was added, but apparently it breaks webforms where GoCardless is configured as a payment processor.

Before
----------------------------------------
When submitting a webform where GoCardless is configured as a payment processor:

![2024-01-10 21_33_41-testgc _ Site-Install](https://github.com/compucorp/webform_civicrm/assets/6275540/c0cd2509-6a39-49f3-8eef-a15bce62eb59)

The webform fails when clicking "submit" before the redirection to GoCardless happens:


![dsadsadsa](https://github.com/compucorp/webform_civicrm/assets/6275540/0db0e689-b36c-4cdd-baeb-11b42ff0b7a3)


After
----------------------------------------
Webforms where GoCardless is configured as a payment processor are working fine:

![cassaas](https://github.com/compucorp/webform_civicrm/assets/6275540/1ba85a89-832a-4b2b-9c44-6b38f5cd7828)



Technical Details
----------------------------------------
The payment processor entity in CiviCRM have a field called `billing_mode`, the value of this field is set based on the nature of the payment processor, for example GoCardless payment processor (that is added by our GoCardless integration extension) sets the value of this field to `CRM_Core_Payment::BILLING_MODE_NOTIFY` given the user does not input any banking or credit card information inside any of the website forms and instead they will be redirected to GoCardless form, while something like the dummy payment processor that is shipped with CiviCRM by default have this field set to `CRM_Core_Payment::BILLING_MODE_LIVE` given it takes the credit card number and the rest of the billing information inside the website forms (such as webforms or contribution pages instead of redirecting the user to a 3rd party website).

The webform_civicrm module differentiate between live payment processors (the ones with `CRM_Core_Payment::BILLING_MODE_LIVE` such as the dummy payment processor), and the ones that aren't , where the following code will be called for live payment processors:

https://github.com/compucorp/webform_civicrm/blob/7.x-5.4-patch5/includes/wf_crm_webform_postprocess.inc#L95-L97

and the following for non live payment processors (such as GoCardless):

https://github.com/compucorp/webform_civicrm/blob/7.x-5.4-patch5/includes/wf_crm_webform_postprocess.inc#L158-L167

in case of non live payment processors, webform_civicrm will try to load the contact ids for any "Contact reference" webform field (by calling $this->fillContactRefs()) and store them inside the webform data array `$this->data` , where in live payment processors such thing won't happen, so the `contribution_contact_id` field that was added to the webform contribution tab in the previous PR will contain the "number" of the selected contact in case of live payment processors:


![2024-01-10 20_55_47-compuclient3website – wf_crm_webform_postprocess inc](https://github.com/compucorp/webform_civicrm/assets/6275540/3c8a58a3-e60b-4181-9d35-77451faecf1a)


while in case of non live payment processors (such as GoCardless) this field will contain the contact actual id:


![2024-01-10 20_57_42-compuclient3website – wf_crm_webform_postprocess inc](https://github.com/compucorp/webform_civicrm/assets/6275540/367a7d41-c615-4c80-8fde-5b8b28aa0f41)


so later on when this code runs inside `contributionParams()` function:
```
    // Get contribution contact id.
    $contribution_contact_id = $params['contribution_contact_id'];
    // Set default contact 1 if contribution contact is empty.
    // This is specifically added for user select option.
    // If user do not choose any option from contribution contact field,
    // then assign default contact 1 as contribution contact.
    if (empty($contribution_contact_id)) {
      $contribution_contact_cid = $this->ent['contact'][1]['id'];
    }
    // Pay later option, where payment processor is not selected.
    elseif (empty($params['payment_processor_id'])) {
      $contribution_contact_cid = $contribution_contact_id;
    }
    else {
      $contribution_contact_cid = $this->ent['contact'][$contribution_contact_id]['id'];
    }
```
and mainly the last bit which is responsible for fetching the contribution contact id in case a payment processor is configured on the webform:

```
    else {
      $contribution_contact_cid = $this->ent['contact'][$contribution_contact_id]['id'];
    }
```

the $contribution_contact_cid  will be not be retrieved correctly in case of non live payment processors given $contribution_contact_id will point to the selected contact id instead of the contact number and given that the `$this->ent['contact']` array is indexed by the contact number, so the $contribution_contact_cid will be null and will result in failure.

I fixed the problem here by adding a Boolean flag to the `contributionParams()` function so we can tell if it is called from live or non live payment processor context.