### PR TITLE
PROD-122: Add proper support for additional line items feature

### DIFF
--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -1041,7 +1041,7 @@ class wf_crm_admin_form {
       '#type' => 'select',
       '#title' => t('Additional Line items'),
       '#default_value' => $num,
-      '#options' => range(0, 9),
+      '#options' => range(0, 49),
       '#prefix' => '<div class="number-of">',
       '#suffix' => '</div>',
     ];

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -2253,7 +2253,9 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $contributionResult = CRM_Contribute_BAO_Contribution::getValues(['id' => $id], CRM_Core_DAO::$_nullArray, CRM_Core_DAO::$_nullArray);
 
     // Save line-items
+    $lineItemNumber = 0;
     foreach ($this->line_items as &$item) {
+      $lineItemNumber++;
       if (empty($item['line_total'])) {
         continue;
       }
@@ -2290,6 +2292,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         $priceFieldID = wf_civicrm_api('PriceField', 'get', [
           'sequential' => 1,
           'price_set_id' => 'default_contribution_amount',
+          'name' => 'webform_additional_line_item_' . $lineItemNumber,
           'options' => ['limit' => 1],
         ])['id'] ?? NULL;
         $item['price_field_id'] = $priceFieldID;

--- a/webform_civicrm.install
+++ b/webform_civicrm.install
@@ -36,6 +36,13 @@ function webform_civicrm_requirements($phase) {
 }
 
 /**
+ * Implements hook_install().
+ */
+function webform_civicrm_install() {
+  _webform_civicrm_generatePriceFields(100);
+}
+
+/**
  * Implements hook_schema().
  */
 function webform_civicrm_schema() {
@@ -831,4 +838,52 @@ function webform_civicrm_update_7403() {
     'default' => 0,
   ];
   db_add_field('webform_civicrm_forms', 'create_new_relationship', $field);
+}
+
+function webform_civicrm_update_7404() {
+  _webform_civicrm_generatePriceFields(50);
+}
+
+/**
+ * Create "Price fields" for "additional line items" functionality.
+ */
+function _webform_civicrm_generatePriceFields($numberOfFieldsToCreate) {
+  civicrm_initialize();
+  $priceField = civicrm_api3('PriceField',
+    'getsingle',
+    [
+      'price_set_id' => civicrm_api3('PriceSet', 'getvalue', ['name' => 'default_contribution_amount', 'return' => 'id']),
+      'options' => ['limit' => 1],
+    ]
+  );
+  $priceFieldParams = $priceField;
+  unset($priceFieldParams['id'], $priceFieldParams['name'], $priceFieldParams['weight'], $priceFieldParams['is_required']);
+  $priceFieldValue = civicrm_api3('PriceFieldValue',
+    'getsingle',
+    [
+      'price_field_id' => $priceField['id'],
+      'options' => ['limit' => 1],
+    ]
+  );
+  $priceFieldValueParams = $priceFieldValue;
+  unset($priceFieldValueParams['id'], $priceFieldValueParams['name'], $priceFieldValueParams['weight']);
+  for ($i = 1; $i <= $numberOfFieldsToCreate; ++$i) {
+    $name = 'webform_additional_line_item_' . $i;
+    $params = array_merge($priceFieldParams, ['label' => ts('Webform Additional Line Item') . " $i", 'name' => $name]);
+    $priceField = civicrm_api3('PriceField', 'get', $params)['values'];
+    if (empty($priceField)) {
+      $p = civicrm_api3('PriceField', 'create', $params);
+      civicrm_api3('PriceFieldValue', 'create', array_merge(
+        $priceFieldValueParams,
+        [
+          'label' => ts('Webform Additional Item') . " $i",
+          'name' => $name,
+          'price_field_id' => $p['id'],
+        ]
+      ));
+    }
+    else {
+      civicrm_api3('PriceField', 'create', ['id' => key($priceField), 'is_active' => TRUE]);
+    }
+  }
 }


### PR DESCRIPTION
Overview
----------------------------------------
In this PR: https://github.com/compucorp/webform_civicrm/pull/44


Before
----------------------------------------
After the work in this PR: https://github.com/compucorp/webform_civicrm/pull/44
and is written under the "the additional line items problem" section, the "additional  line items" feature in webform-civicrm integration is no longer working  where an error will be thrown when additional line items are configured.

After
----------------------------------------
The additional line items feature is now working fine, and I also increased the number of supported additional line items to 50 instead of only 10.


here is how now up to 50 line items can be added:
![2024-01-15 20_38_20-](https://github.com/compucorp/webform_civicrm/assets/6275540/e3b8e4f1-150d-4e94-95a1-788c2e745407)

and here is an example webform configured with 3 line items

![image](https://github.com/compucorp/webform_civicrm/assets/6275540/4f30e72f-95a3-455c-a932-21b3a4f00e50)

and here is a demo for submitting this webform:


https://github.com/compucorp/webform_civicrm/assets/6275540/f2fe1e9a-e51f-41e0-adfd-24f09a12589b

and here is the contribution that got created as a result:

![image](https://github.com/compucorp/webform_civicrm/assets/6275540/31f92233-fc2f-4aa5-a664-03b72fbe1efc)


Technical Details
----------------------------------------
The full technical of the problem and how it started is already discussed in this PR:  https://github.com/compucorp/webform_civicrm/pull/44

but the solution I went up with is similar to how the [Line Item Editor](https://lab.civicrm.org/extensions/lineitemedit) extension handles adding additional line items, which is explained in my comment under this PR: https://github.com/compucorp/lineitemedit/pull/3

which is basically creating 50 price fields with a price field value under each one, in this case I named these price fields: `webform_additional_line_item_X` where X goes from 1 to 50 for each line item, I've implemented the webform install hook and added an upgrader to handle adding these 50 price fields and price field values, then inside the code that processes the contributions after submitting the webform, I set the `price_field_id` and the `price_field_value_id` for each additional line items configured on the webform to one of these price fields.
