### PR TITLE
ESEB-130: Calculate the correct membership end date for 'manually entered dates' config

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1227,6 +1227,15 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         unset($params['auto_renew']);
       }
 
+      // When the membership on the Webform is configured with "Enter Dates Manually" option
+      // then the "Number Of Terms" will be 0 (empty), but having the "Number Of terms" set to
+      // 0 prevent CiviCRM from calculating the membership dates correctly, specially the end
+      // date if it is not ticked on the membership configuration tab, and it might result
+      // in problems in other areas (like renewal).
+      if (empty($params['num_terms'])) {
+        $params['num_terms'] = 1;
+      }
+
       $result = wf_civicrm_api('membership', 'create', $params);
 
       if (!empty($result['id'])) {


### PR DESCRIPTION
Before
----------------------------------------
If you configure a webform with:
- a 1 year rolling membership
- number of terms set to "Enter Dates Manually"
- "Start Date" box is ticked , but the "End Date" box is left empty
- Set a default value for the "Start date" such as "2023-10-01"

![2024-01-25 20_47_02-ESEB-129 _ Site-Install](https://github.com/compucorp/webform_civicrm/assets/6275540/5280f3af-8904-41ae-82d7-3662663f1549)


Then after you submit the webform, a membership will be created with end date = "30 of September 2023" instead of  "30 of September 2024":

![image](https://github.com/compucorp/webform_civicrm/assets/6275540/fcbed4bd-93a8-4170-aede-7876560217f7)


This problem does not only happen with the mentioned dates but any other dates, and it also applies to fixed memberships.


After
----------------------------------------

The membership in the example above will be created with correct end date which is "30 of September 2024":

![image](https://github.com/compucorp/webform_civicrm/assets/6275540/49fc2d8f-955f-425e-bec0-a5501328c49a)

and in general the membership end date will be calculated correctly.

Technical Details
----------------------------------------
Webform_civicrm in general assumes that memberships with "Manually Entered Dates" to be free memberships, and because this behavior does not suites us at Compuco, I've changed it here: https://github.com/compucorp/webform_civicrm/pull/52

But the other part of it is that this module sets the membership "Number of terms" to zero as well,  but having the "Number Of terms" set to 0 prevents CiviCRM from calculating the membership dates correctly (mainly if you have the end date checkbox unticked) given it will be passed to this CiviCRM method: https://github.com/civicrm/civicrm-core/blob/5.51.3/api/v3/Membership.php#L97-L102 that only knows how to calculate the membership dates (mainly the end date) if the number of terms is at least set to 1.

 Not to mention that having the number of terms stored set to 0 might possibly affect memberships autorenewal and possibly other things. So My fix here is simply to set the number of terms to be "1" if the "Enter Dates Manually" option is selected on the membership.


