### PR TITLE
CIVIPLMMSR-166: Fix missing price field on membership line items after manual renewal

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -2301,6 +2301,22 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
             $item['id'] = $firstLineItem['id'];
           }
         }
+
+        if (empty($item['price_field_id'])) {
+          $membershipTypeId = wf_civicrm_api('Membership', 'getvalue', [
+            'return' => 'membership_type_id',
+            'id' => $item['membership_id'],
+          ]);
+          $priceFieldValue = wf_civicrm_api('PriceFieldValue', 'get', [
+            'sequential' => 1,
+            'membership_type_id' => $membershipTypeId,
+            'options' => ['sort' => 'id asc', 'limit' => 1],
+          ]);
+          if ($priceFieldValue['count'] > 0) {
+            $item['price_field_id'] = $priceFieldValue['values'][0]['price_field_id'];
+            $item['price_field_value_id'] = $priceFieldValue['values'][0]['id'];
+          }
+        }
       }
       else {
         // sets price field and price field value for non membership line items.


### PR DESCRIPTION
Before
----------------------------------------
An error is thrown when trying to download the invoice for the contribution that gets created after renewing a membership through a webform:


https://github.com/compucorp/webform_civicrm/assets/6275540/2ef67d01-e03d-46ed-8902-30f87e999a8b




After
----------------------------------------
Invoices after webform renewal can be downloaded just fine:

https://github.com/compucorp/webform_civicrm/assets/6275540/842ca1a9-3a34-4778-b17f-7b7d902d7aec




Technical Details
----------------------------------------

The error that shows up in the logs is this:

```
|TypeError: CRM_Financial_BAO_Order::getPriceSetID(): Return value must be of type int, null returned in CRM_Financial_BAO_Order->getPriceSetID() (line 461 of /var/www/default/htdocs/httpdocs/profiles/compuclient/modules/contrib/civicrm/CRM/Financial/BAO/Order.php)
```

which is caused by missing `price_field_id` and `price_field_value_id` on the line item.

We had similar problem before when "Additional line items" are used, which is a problem that I explained and fixed here: https://github.com/compucorp/webform_civicrm/pull/55

but I did not face it with memberships because when I tested things back then I only tested membership creation but not renewal, it seems that when you create a membership through webform, the line items will be created by the Membership BAO class, given it only create line items if no membership id is provided to it:

https://github.com/civicrm/civicrm-core/blob/5.51.3/CRM/Member/BAO/Membership.php#L343-L348
https://github.com/civicrm/civicrm-core/blob/5.51.3/CRM/Member/BAO/Membership.php#L371-L405

and there CiviCRM will figure out what the price_field_id and price_field_value_id will be set to, based on the selected membership type.

Where in renewal, the line items will be created by the webform_civicrm module instead, but as you can see in the lines I changed in this PR and before my change, webform_civicrm  module does set any of these two fields to anything, so they end up to empty.


Hence that this fix only affects new renewals, but for memberships that are already renewed with these fields missing, we will need to run the following SQL queries to fix them (I decided not to do this in an upgrader because I think it safer to do them manually) :


1- This will get the list of affected contributions/line items:

```
SELECT id, contribution_id, price_field_id, price_field_value_id from civicrm_line_item where price_field_id is null and price_field_value_id is null and contribution_id IS NOT NULL;
```

2- And this to update these fields based on the linked membership type:

```
UPDATE civicrm_line_item cli
JOIN civicrm_membership cm ON cli.entity_id = cm.id
LEFT JOIN (
    SELECT cpfv.*
    FROM civicrm_price_field_value cpfv
    JOIN civicrm_membership cm_sub ON cpfv.membership_type_id = cm_sub.membership_type_id
) AS cpfv ON 1=1
SET cli.price_field_id = cpfv.price_field_id,
    cli.price_field_value_id = cpfv.id
WHERE cli.price_field_id IS NULL
  AND cli.price_field_value_id IS NULL
  AND cli.entity_table = 'civicrm_membership'
  AND cpfv.id = (
    SELECT cpfv_sub.id
    FROM civicrm_price_field_value cpfv_sub
    WHERE cpfv_sub.membership_type_id = cm.membership_type_id
    ORDER BY cpfv_sub.id
    LIMIT 1
  );
```


3- And in case you want to see what we will be inside price_field_id and price_field_value_id  before running query number 2, you can run this query:


```
SELECT cli.id, cli.contribution_id, cpfv.price_field_id, cpfv.id AS price_field_value_id
FROM civicrm_line_item cli
JOIN civicrm_membership cm ON cli.entity_id = cm.id
LEFT JOIN civicrm_price_field_value cpfv ON cpfv.membership_type_id = cm.membership_type_id
WHERE cli.price_field_id IS NULL
  AND cli.price_field_value_id IS NULL
  AND cli.entity_table = 'civicrm_membership'
  AND cpfv.id = (
    SELECT cpfv_sub.id
    FROM civicrm_price_field_value cpfv_sub
    WHERE cpfv_sub.membership_type_id = cm.membership_type_id
    ORDER BY cpfv_sub.id
    LIMIT 1
  );
```


