### PR TITLE
FOSFA-258: Fix file access and filename issue on "My Cases"

### DIFF
--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -750,11 +750,14 @@ abstract class wf_crm_webform_base {
       $config = CRM_Core_Config::singleton();
       $path = file_unmanaged_copy($file->uri, $config->customFileUploadDir);
       if ($path) {
-        $result = wf_civicrm_api('file', 'create', [
-          'uri' => str_replace($config->customFileUploadDir, '', $path),
-          'mime_type' => $file->filemime,
+        $result = civicrm_api4('File', 'create', [
+          'values' => [
+            'uri' => str_replace($config->customFileUploadDir, '', $path),
+            'mime_type' => $file->filemime,
+          ],
+          'checkPermissions' => FALSE,
         ]);
-        return wf_crm_aval($result, 'id');
+        return wf_crm_aval($result->first(), 'id');
       }
     }
     return NULL;

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -750,9 +750,11 @@ abstract class wf_crm_webform_base {
       $config = CRM_Core_Config::singleton();
       $path = file_unmanaged_copy($file->uri, $config->customFileUploadDir);
       if ($path) {
+        $name = str_replace($config->customFileUploadDir, '', $path);
+        $file_uri = CRM_Utils_File::makeFileName($name);
         $result = civicrm_api4('File', 'create', [
           'values' => [
-            'uri' => str_replace($config->customFileUploadDir, '', $path),
+            'uri' => $file_uri,
             'mime_type' => $file->filemime,
           ],
           'checkPermissions' => FALSE,


### PR DESCRIPTION
Overview
----------------------------------------
This PR changes aims to fix the file access issue by assigning the correct owner to the file.

This also fixed the filename issue which was display empty on the My cases

D7 or D8?
----------------------------------------
Drupal 7

Before
----------------------------------------
Files from case activities created by webform wasn't appearing in Documents area of My Cases.

![Screenshot 2024-03-12 at 5 47 21 PM](https://github.com/compucorp/webform_civicrm/assets/131177317/d3ef3c16-8d1b-44d8-aeb1-69213fe1f571)


http://tinyurl.com/yu7h4ffp (submitting file from webform)

http://tinyurl.com/ytqgn9cu (submitting file directly as admin to the case → this seems to work successfully)

**Filename looks incomplete**

![Screenshot 2024-03-20 at 4 00 36 PM](https://github.com/compucorp/webform_civicrm/assets/131177317/a73b43c2-6f29-4bc7-8e0e-24935615c452)


After
----------------------------------------
Added fix to add created_id to file, so that it would be accessible for user in "My Cases" .

![Screenshot 2024-03-12 at 5 46 42 PM](https://github.com/compucorp/webform_civicrm/assets/131177317/7a3237bf-4da8-4ead-85f0-b69a6cd55686)

**Filename Fixed Now**

![Screenshot 2024-03-20 at 4 01 03 PM](https://github.com/compucorp/webform_civicrm/assets/131177317/61fb8d4e-d525-473e-8770-ac207dea90fd)


Technical Details
----------------------------------------
### Commit 1 - FOSFA-258: Fix file access issue for my cases

**RCA:** The `created_id` field is not getting assigned to the File uploaded by the webform. 
Its only getting assigned to the file which is uploaded directly from CIVICRM dashboard, hence those files are visible in the `SSP → My Cases → View Documents` section.

![Screenshot 2024-03-12 at 4 13 14 PM](https://github.com/compucorp/webform_civicrm/assets/131177317/4b4af8b3-0398-4a11-94e2-05410f846290)

- Create function has assigning the `created_id` like [this](https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/BAO/File.php#L50)
- With API3 this `create` method is not getting executed for the file upload from the webform.
- API v3 does not call the BAO method  because the API overrides the `create` action implementation [here](https://github.com/civicrm/civicrm-core/blob/master/api/v3/File.php#L32) it calls the underlying DAO class [here](https://github.com/civicrm/civicrm-core/blob/master/api/v3/File.php#L40-L57)
- So we changed the implementation from API3 to API4 for `saveDrupalFileToCivi()` [method](https://github.com/compucorp/webform_civicrm/blob/7.x-5.4-patches/includes/wf_crm_webform_base.inc#L747).
- While API4 does not override anything so this is working fine with API4 - [Check](https://github.com/civicrm/civicrm-core/blob/master/Civi/Api4/File.php)

![Screenshot 2024-03-12 at 4 12 39 PM](https://github.com/compucorp/webform_civicrm/assets/131177317/2398f011-3ff8-4a06-8c4e-7076240fb885)

### Commit 2 - FOSFA-258: Fix filename issue for my cases
- Making a valid file name before sending it to civicrm by using the `makeFileName` from `CRM_Utils_File` file object class.
- When upload the file directly from civicrm it added the 32 bit md5 hash string on file name like this
![Screenshot 2024-03-20 at 4 02 10 PM](https://github.com/compucorp/webform_civicrm/assets/131177317/1585a587-6535-4146-b8e2-c4bd3c177e82)
- This 32 but md5 hash not added when file uploaded from Drupal to civicrm.
![Screenshot 2024-03-20 at 4 02 34 PM](https://github.com/compucorp/webform_civicrm/assets/131177317/0069d900-3289-492a-b365-57e8cd41ac97)
- When it renders on the Drupal My cases section this hash gets removed while querying the data - https://github.com/compucorp/ssp_core/blob/master/modules/ssp_core_cases/src/DocumentsView.php#L105
- To fix this have added the `makeFileName` to file URI.


