### PR TITLE
FOSFAB-317: Allow Case Roles With Case Edit Permissions To Edit The Case Via Webforms

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1345,17 +1345,49 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
           // These params aren't allowed in update mode
           unset($params['creator_id']);
 
+          $caseContacts = wf_civicrm_api(
+            'CaseContact',
+            'get',
+            ['case_id' => $params['id'], 'sequential' => TRUE, 'return' => ['contact_id']]
+          );
+          $caseContacts = array_column($caseContacts['values'] ?? [], 'contact_id');
+          $clientId = current((array) $params['client_id']);
           // If orig_contact_id is missing and there's more than one Contact
           // on the Case, set orig_contact_id to the current ID. Otherwise
           // we get a Case.create error "Case is linked with more than one
           // contact id".
-          if (empty($params['orig_contact_id']) && !empty($params['id'])) {
-            $caseContactCount = wf_civicrm_api('CaseContact', 'getcount', ['case_id' => $params['id']]);
-            if ($caseContactCount > 1 && !empty($params['client_id'])) {
-              $params['orig_contact_id'] = current((array) $params['client_id']);
-            }
+          if (empty($params['orig_contact_id']) && !empty($params['id']) && count($caseContacts) > 1 && !empty($clientId)) {
+            $params['orig_contact_id'] = in_array($clientId, $caseContacts) ? $clientId : $caseContacts[0];
           }
 
+          if (user_access('Update cases with user role via webform')) {
+            $allContacts = [];
+            $userHasACaseRole = FALSE;
+            foreach ($this->ent['contact'] as $contact) {
+              if (!empty($contact['id'])) {
+                $allContacts[] = $contact['id'];
+              }
+            }
+
+            $relationships = \Civi\Api4\Relationship::get()
+              ->setCheckPermissions(FALSE)
+              ->setSelect(['contact_id_b'])
+              ->addWhere('is_current', '=', TRUE)
+              ->addWhere('case_id', '=',  $params['id'])
+              ->execute()
+              ->getArrayCopy();
+
+            foreach ($relationships as $relationship) {
+              if (in_array($relationship['contact_id_b'], $allContacts)) {
+                $userHasACaseRole = TRUE;
+                break;
+              }
+            }
+
+            if ($userHasACaseRole) {
+              $params['contact_id'] = $caseContacts;
+            }
+          }
         }
         // Allow "automatic" status to pass-thru
         if (empty($params['status_id'])) {

--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -646,10 +646,28 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
             if (array_intersect((array) wf_crm_aval($item, 'client_id'), $clients) || user_access('access all cases and activities')) {
               $this->ent['case'][$n] = ['id' => $id];
             }
+            else if (user_access('Update cases with user role via webform')) {
+              civicrm_initialize();
+              $relationships = \Civi\Api4\Relationship::get()
+                ->setCheckPermissions(FALSE)
+                ->setSelect(['contact_id_b'])
+                ->addWhere('is_current', '=', TRUE)
+                ->addWhere('case_id', '=', $id)
+                ->execute()
+                ->getArrayCopy();
+
+              foreach ($relationships as $relationship) {
+                if (in_array($relationship['contact_id_b'], $allContacts)) {
+                  $this->ent['case'][$n] = ['id' => $id];
+                  break;
+                }
+              }
+            }
             else {
               foreach ($item['contacts'] ?? [] as $caseContact) {
                 if (!empty($caseContact['manager']) && in_array($caseContact['contact_id'], $allContacts)) {
                   $this->ent['case'][$n] = ['id' => $id];
+                  break;
                 }
               }
             }


### PR DESCRIPTION
Overview
----------------------------------------
This pr allows users to edit the case details if they have a current case role and **Update cases with user role via webform** permissions.

Before
----------------------------------------
When any case role other than client submitted the webform a new case was opened and existing case got deleted.

After
----------------------------------------
If the user submitting the webform has **Update cases with user role via webform**  and he also posseses a current case role then the case details will be updated otherwise a new case will be opened and existing case will be deleted.