### PR TITLE
FEMSSPRT-346: Configurable search results limit for autocomplete fields

### DIFF
--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -664,7 +664,7 @@ function wf_crm_contact_search($node, $component, $params, $contacts, $str = NUL
   if (empty($node->webform_civicrm)) {
     return [];
   }
-  $limit = $str ? 12 : 500;
+  $limit = $str ? $node->webform_civicrm['autocomplete_search_results_limit'] : 500;
   $ret = [];
   $display_fields = array_values($component['extra']['results_display']);
   $search_field = 'display_name';

--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -1185,6 +1185,14 @@ class wf_crm_admin_form {
       '#default_value' => $this->settings['new_contact_source'],
       '#description' => t('Optional "source" label for any new contact/participant/membership created by this webform.'),
     ];
+    $this->form['options']['autocomplete_search_results_limit'] = [
+      '#type' => 'textfield',
+      '#title' => t('Autocomplete Search Results Limit'),
+      '#maxlength' => 255,
+      '#size' => 30,
+      '#default_value' => $this->settings['autocomplete_search_results_limit'],
+      '#description' => t('Search results limit for autocomplete field on webform.'),
+    ];
   }
 
   /**

--- a/webform_civicrm.install
+++ b/webform_civicrm.install
@@ -114,6 +114,13 @@ function webform_civicrm_schema() {
         'default' => '',
         'description' => 'Source label for newly created contacts',
       ],
+      'autocomplete_search_results_limit' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+        'default' => '',
+        'description' => 'Search results limit for autocomplete field on webform.',
+      ],
     ],
     'primary key' => ['nid'],
   ];
@@ -886,4 +893,18 @@ function _webform_civicrm_generatePriceFields($numberOfFieldsToCreate) {
       civicrm_api3('PriceField', 'create', ['id' => key($priceField), 'is_active' => TRUE]);
     }
   }
+}
+
+/**
+ * Add column for autocomplete_search_results_limit to webform_civicrm_forms table.
+ */
+function webform_civicrm_update_7405() {
+  $field = [
+    'type' => 'varchar',
+    'length' => 255,
+    'not null' => TRUE,
+    'default' => '',
+    'description' => 'Search results limit for autocomplete field on webform.',
+  ];
+  db_add_field('webform_civicrm_forms', 'autocomplete_search_results_limit', $field);
 }


### PR DESCRIPTION
Overview
----------------------------------------
PR aims to make search results limit configurable for autocomplete fields used in webform.


Before
----------------------------------------
[screencast-bpconcjcammlapcogcnnelfmaeghhagj-2024.08.09-18_05_38.webm](https://github.com/user-attachments/assets/2a37219f-30b7-4207-8126-7e9235563883)


After
----------------------------------------
[screencast-bpconcjcammlapcogcnnelfmaeghhagj-2024.08.09-18_03_56.webm](https://github.com/user-attachments/assets/58e8c6ae-987f-44a7-80a3-ff29c7eb7245)


Technical Details
----------------------------------------

- Added new configuration for set autocomplete search results limit in civicrm tab - "additional options" section.
- Added upgrader to add newly added settings in webform_civicrm_forms table.
- Added table details in webform_civicrm_schema() for new clients.
- Used newly added configuration to setup autocomplete search results limit.
