### PR TITLE
FEMSSPRT-346: Add default search results limit for autocomplete fields

### DIFF
--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -1281,6 +1281,7 @@ class wf_crm_admin_form {
       'confirm_subscription' => 1,
       'create_fieldsets' => 1,
       'new_contact_source' => check_plain($this->node->title),
+      'autocomplete_search_results_limit' => 12,
       'civicrm_1_contact_1_contact_first_name' => 'create_civicrm_webform_element',
       'civicrm_1_contact_1_contact_last_name' => 'create_civicrm_webform_element',
       'civicrm_1_contact_1_contact_existing' => 'create_civicrm_webform_element',

--- a/webform_civicrm.install
+++ b/webform_civicrm.install
@@ -118,7 +118,7 @@ function webform_civicrm_schema() {
         'type' => 'varchar',
         'length' => 255,
         'not null' => TRUE,
-        'default' => '',
+        'default' => 12,
         'description' => 'Search results limit for autocomplete field on webform.',
       ],
     ],
@@ -903,7 +903,7 @@ function webform_civicrm_update_7405() {
     'type' => 'varchar',
     'length' => 255,
     'not null' => TRUE,
-    'default' => '',
+    'default' => 12,
     'description' => 'Search results limit for autocomplete field on webform.',
   ];
   db_add_field('webform_civicrm_forms', 'autocomplete_search_results_limit', $field);


### PR DESCRIPTION
Overview
----------------------------------------
PR aims to add default search results limit for autocomplete fields


Before
----------------------------------------
[screencast-bpconcjcammlapcogcnnelfmaeghhagj-2024.08.09-18_05_38.webm](https://github.com/user-attachments/assets/2a37219f-30b7-4207-8126-7e9235563883)


After
----------------------------------------
[screencast-bpconcjcammlapcogcnnelfmaeghhagj-2024.08.09-18_03_56.webm](https://github.com/user-attachments/assets/58e8c6ae-987f-44a7-80a3-ff29c7eb7245)


Technical Details
----------------------------------------

- Added default value for newly added field in webform_civicrm_schema().
- Added default value for newly added field in upgrader.
- Set default settings value for newly added field.
