### PR TITLE
FEMSSPRT-345: Allow html characters in autocomplete results

### DIFF
--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -88,7 +88,8 @@ function _webform_edit_civicrm_contact($component) {
     noResultsText: "' . t('Not found') . '",
     searchingText: "' . t('Searching...') . '",
     tokenLimit: 1,
-    prePopulate: prep
+    prePopulate: prep,
+    enableHTML: true
   }';
   $js = '
   jQuery(function($) {
@@ -458,7 +459,8 @@ function _webform_render_civicrm_contact($component, $value = NULL, $filter = TR
         $settings = '{
           hintText: ' . json_encode(filter_xss($component['extra']['search_prompt'])) . ',
           noResultsText: ' . json_encode(filter_xss($component['extra']['none_prompt'])) . ',
-          searchingText: ' . json_encode(t('Searching...')) . '
+          searchingText: ' . json_encode(t('Searching...')) . ',
+          enableHTML: ' . json_encode('true') . '
         }';
         $js = "wfCivi.existingInit(field, $c, {$node->nid}, $callback_path, toHide, $settings);$onChange";
       }


### PR DESCRIPTION
Overview
----------------------------------------
PR aims to allow html characters in autocomplete results. After this change Apostrophe & other html characters in autocomplete field on webform display correctly.


Before
----------------------------------------
[screencast-bpconcjcammlapcogcnnelfmaeghhagj-2024.08.12-19_21_31.webm](https://github.com/user-attachments/assets/ec299437-af46-48dd-8e7c-99e6fecc6c61)



After
----------------------------------------
[screencast-bpconcjcammlapcogcnnelfmaeghhagj-2024.08.12-19_20_19.webm](https://github.com/user-attachments/assets/dffbaee6-5ae6-459f-a6a3-abfc1b59dd7e)


Technical Details
----------------------------------------

- Allow html characters in autocomplete results(enableHTML: true).
