### PR TITLE
FEMSSPRT-346: Add fix height and scrollbar to autocomplete field

### DIFF
--- a/css/token-input.css
+++ b/css/token-input.css
@@ -84,6 +84,8 @@ div.token-input-dropdown {
     cursor: default;
     font-size: 12px;
     font-family: Verdana;
+    max-height: 25%;
+    overflow-y: auto;
 }
 
 div.token-input-dropdown p {


### PR DESCRIPTION
Overview
----------------------------------------
PR aims to add fix height and scrollbar to autocomplete field


Before
----------------------------------------

[screencast-compuclient-dist_ddev_site-2024_09_30-14_23_19.webm](https://github.com/user-attachments/assets/cc7eec23-b241-4493-824c-81c98c2fdb71)


After
----------------------------------------

[screencast-compuclient-dist_ddev_site-2024_09_30-13_53_26.webm](https://github.com/user-attachments/assets/6fa27da1-e7a7-4b30-8cac-248407d412be)


Technical Details
----------------------------------------

- Added fix height & scrollbar to autocomplete field in `css/token-input.css` 
- In webform we have added specific height `25%` of viewport & `vertical scrollbar` to autocomplete field.
