### PR TITLE
BTHAMM-39: Fix File Upload To Civicrm

### DIFF
--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -748,10 +748,9 @@ abstract class wf_crm_webform_base {
     $file = file_load($id);
     if ($file) {
       $config = CRM_Core_Config::singleton();
-      $path = file_unmanaged_copy($file->uri, $config->customFileUploadDir);
+      $file_uri = CRM_Utils_File::makeFileName($file->filename ?? '');
+      $path = file_unmanaged_copy($file->uri, $config->customFileUploadDir . $file_uri);
       if ($path) {
-        $name = str_replace($config->customFileUploadDir, '', $path);
-        $file_uri = CRM_Utils_File::makeFileName($name);
         $result = civicrm_api4('File', 'create', [
           'values' => [
             'uri' => $file_uri,


### PR DESCRIPTION
Overview
----------------------------------------
This pr fixes an issue in webform submission due to which the uploaded files were not accessible on civicrm.

Technical Details
----------------------------------------
The issue was that when uploading the file to civicrm's custom upload directory the file hash was not used but while saving the file in database the filename was appended with file hash. So when user tried to download the file the file path included the file hash and that resulted in a file not found error. This pr chnages the code so the file is uploaded with file hash included in file name to civicrm's custom upload directory.
