### PR TITLE
FEMSSPRT-376: Fix Duplicate Contact Detection

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -147,6 +147,10 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       // Create new contact
       if ($newContact) {
         $this->ent['contact'][$c]['id'] = $this->createContact($contact);
+        if (!empty($contact['email'][1]['email'])) {
+          $emailParams = $contact['email'][1] + ['contact_id' => $this->ent['contact'][$c]['id'], 'is_primary' => 1];
+          wf_civicrm_api('email', 'create', $emailParams);
+        }
       }
       if ($c == 1) {
         $this->setLoggingContact();


### PR DESCRIPTION
Overview
----------------------------------------
This pr fixes the detection of duplicate contact. Prior to this pr if a dedupe rule used email field for detecting duplicates then it did not work if the duplicates were between the contacts other than the first contact as the email for first contact is saved at the time of validation but for other contacts the emails are saved at the end after all the contacts have been created and for this scenario two different contacts were getting created through webform submission even if they have same dedupe rule fields. This pr fixes the issue and now the duplicate contacts are detected successfully.

core pr: https://github.com/colemanw/webform_civicrm/pull/1033