### PR TITLE
CIWEMSPRT-49: Fix Financial Transaction Records

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -2044,7 +2044,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
 
     $params = $this->contributionParams(FALSE);
     $params['contribution_status_id'] = 'Pending';
-    $params['is_pay_later'] = $this->contributionIsPayLater;
+    $params['is_pay_later'] = TRUE;
 
     $numInstallments = wf_crm_aval($params, 'installments', NULL, TRUE);
     $frequencyInterval = wf_crm_aval($params, 'frequency_unit');


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes an issue related to creation of deffered contributions in which payments will be taken redirecting to payment processor platform like in the case of gocardless. In this scenario webform is currently creating pending(Incomplete transaction) whereas it should be creating pending (pay later) transactions because for pending(Incomplete transaction) contribution civicrm does not create any financial transactions so this PR fixes this issue.

Only the processors for which user have to go to the processor platform to complete the payment will get effected by this change i.e the contribution will stay as pay later until the user completes the payment 

The change 

Before
----------------------------------------
When user completes the webform using gocardless as payment processor the contribution gets created as  pending(Incomplete transaction) and no financial record is created i.e no rows in civicrm_financial_trxn and civicrm_entity_financial_trxn tables

After
----------------------------------------
When user completes the webform using gocardless as payment <img width="1792" alt="Screenshot 2025-03-17 at 1 48 48 PM" src="https://github.com/user-attachments/assets/ea0425af-36b4-4444-a7b1-5cd7ac8b2fa4" /> the contribution gets created as  pending(Pay later) and following pending financial record gets created
