### PR TITLE
MM-189: Expose membership fee token for webform calculator formula field

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -1243,6 +1243,9 @@ function wf_crm_get_fields($var = 'fields') {
         $fields['membership_fee_amount'] = [
           'name' => t('Membership Fee'),
         ] + $moneyDefaults;
+        $fields['membership_fee_amount_from_membership'] = [
+          'name' => t('Membership Fee (from Membership Type)'),
+        ] + $moneyDefaults;
       }
       $fields['membership_join_date'] = [
         'name' => t('Member Since'),

--- a/includes/wf_crm_webform_ajax.inc
+++ b/includes/wf_crm_webform_ajax.inc
@@ -197,6 +197,22 @@ class wf_crm_webform_ajax extends wf_crm_webform_base {
     return TRUE;
   }
 
+  /**
+   * Populate a membership fees data based on membership type.
+   * @param string $input
+   */
+  function getMembershipFees($input) {
+    $data = [];
+    if (!empty($input) && intval($input)) {
+      $minimum_fee = number_format($this->getMembershipTypeField($input, 'minimum_fee'), 2);
+      if ($minimum_fee) {
+        $data = ['fees' => $minimum_fee];
+      }
+    }
+    drupal_json_output($data);
+    exit();
+  }
+
 }
 
 /**
@@ -211,7 +227,7 @@ class wf_crm_webform_ajax extends wf_crm_webform_base {
  */
 function wf_crm_ajax($key, $input = '') {
   $processor = new wf_crm_webform_ajax();
-  if ($key == 'stateProvince' || $key == 'county') {
+  if ($key == 'stateProvince' || $key == 'county' || $key == 'getMembershipFees') {
     $processor->$key($input);
   }
   elseif (strpos($key, '-')) {

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -598,6 +598,7 @@ abstract class wf_crm_webform_base {
     foreach ($existing as $membership) {
       $membership['is_active'] = $status_types[$membership['status_id']]['is_current_member'];
       $membership['status'] = $status_types[$membership['status_id']]['label'];
+      $membership['fee_amount_from_membership'] = number_format($this->getMembershipTypeField($membership['membership_type_id'], 'minimum_fee'), 2);
       $list = $membership['is_active'] ? 'active' : 'expired';
       array_unshift($$list, $membership);
     }

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1702,7 +1702,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
             $type = $item['membership_type_id'];
             $price = $this->getMembershipTypeField($type, 'minimum_fee');
 
-            if (isset($item['fee_amount'])) {
+            if (!empty($item['fee_amount'])) {
               $price = $item['fee_amount'];
             }
 

--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -432,5 +432,53 @@ var wfCivi = (function ($, D) {
       });
     }
   };
+
+  /**
+   * Update membership type fees field based on selected membership.
+   */
+  D.behaviors.membershipTypeFeesUpdate = {
+    attach: function (context, settings) {
+      const membershipSelector = 'select[id*="membership-membership-type-id"]';
+      // Should apply for multiple membership type.
+      $(membershipSelector, context).each(function() {
+        // On change membership type field.
+        $(membershipSelector, context).once('feeAjax').change(function () {
+          const membershipSelect = $(this);
+          // Get name attribute of membership type.
+          var membershipSelectname = membershipSelect.attr('name');
+          // Pregmatch to fetch fieldset name.
+          // Capture fieldset name inside the first pair of square brackets.
+          var membershipSelectMatch = membershipSelectname.match(/\[([^\[\]]+)\]/);
+          // This is fieldset for each contact.
+          var civiContactFieldset = membershipSelectMatch[1];
+
+          const feeField = 'input[id*="membership-fee-amount-from-membership"]';
+          // Filter the fees input which has same fieldset as name.
+          const feeFieldInput = $(feeField).filter(function() {
+            // Safely checks if the name exists and includes the target.
+            return $(this).attr('name')?.includes(civiContactFieldset);
+          });
+
+          // Make ajax request when fees field present.
+          if (feeFieldInput) {
+            const membershipId = membershipSelect.val();
+            $.ajax({
+              url: '/webform-civicrm/js/getMembershipFees/' + membershipId,
+              dataType: 'json',
+              success: function (response) {
+                if (response.fees !== undefined) {
+                  $(feeFieldInput).val(response.fees);
+                }
+              },
+              error: function () {
+                console.log('Failed to fetch fee.');
+              }
+            });
+          }
+        });
+      });
+    }
+  };
+
   return pub;
 })(jQuery, Drupal);


### PR DESCRIPTION
Overview
----------------------------------------
This PR changes allow the membership fee field available as token to further used in the webform calculator formula field as token.

Detailed Specs: https://compucorp.atlassian.net/wiki/spaces/DruStandard/pages/5111676967/Membership+Tokens

D7 or D8?
----------------------------------------
D7

Before
----------------------------------------
- When adding a membership to a membership purchase webform, it’s not necessary to expose the membership fee value.
- When the fee is not exposed , the fee amount for the membership type is automatically pulled through the contribution page.
- If the the membership fee is exposed, then the value no longer populates based on the membership type selected.

![image-20250129-150329](https://github.com/user-attachments/assets/a748453b-9785-4cb4-8179-210bf78b1157)

**How It Currently Works**
- The Membership Fee field is optional in CiviCRM webforms.
- Webform calculator modules cannot access the Membership Fee value unless explicitly enabled.
- There is no default way to expose the membership fee in a webform for calculations without explicitly including the Membership Fee field.

After
----------------------------------------
**How It is working now**
- A new field called "Membership Fee (from Membership Type)" is created.
- This field automatically pull the latest membership fee from the selected membership type when a form is instantiated.
- Function similarly to the existing "Membership Fee" field, ensuring that membership line items reflect the correct amount.
- It is shown like a normal field.
- It is accessible for use in webform calculator module calculations (e.g., for applying discounts).
- Allow users to set the field to private/hide from webform while still loading the value.

![Screenshot 2025-04-09 at 11 30 36 AM](https://github.com/user-attachments/assets/47e2fcdd-36b7-4ffd-9c97-31e89ca1a213)


https://github.com/user-attachments/assets/f847c76d-2a3f-40db-b017-35c8088eb72d


Technical Details
----------------------------------------
- Create new field `membership_fee_amount_from_membership` under utils.inc.
- Autofill the new field with current membership data in `findMemberships` method
`$membership['fee_amount_from_membership'] = number_format($this->getMembershipTypeField($membership['membership_type_id'], 'minimum_fee'), 2);`
- Added new Drupal behaviour `membershipTypeFeesUpdate` to handle the ajax request for autofilling the membership fee field when changed the membership type field.
- This JS handles the on change part for multiple membership type fields on same form.
- Implemented new method `getMembershipFees` under `includes/wf_crm_webform_ajax.inc` file.
