### PR TITLE
CIVIMM-293: Use string in place of NULL to avoid depreciation error in strtolower

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -400,8 +400,8 @@ function wf_crm_get_relationship_types() {
   static $types = [];
   if (!$types) {
     foreach (wf_crm_apivalues('relationship_type', 'get', ['is_active' => 1]) as $r) {
-      $r['type_a'] = strtolower(wf_crm_aval($r, 'contact_type_a'));
-      $r['type_b'] = strtolower(wf_crm_aval($r, 'contact_type_b'));
+      $r['type_a'] = strtolower(wf_crm_aval($r, 'contact_type_a') ?? "");
+      $r['type_b'] = strtolower(wf_crm_aval($r, 'contact_type_b') ?? "");
       $r['sub_type_a'] = wf_crm_aval($r, 'contact_sub_type_a');
       $r['sub_type_b'] = wf_crm_aval($r, 'contact_sub_type_b');
       $types[$r['id']] = $r;


### PR DESCRIPTION
Overview
----------------------------------------
Before this PR, the following depreciation error was reported

> [PHP Deprecation] strtolower(): Passing null to parameter #1 ($string) of type string is deprecated at /var/www/default/htdocs/httpdocs/profiles/compuclient/modules/contrib/webform_civicrm/includes/utils.in
[PHP Deprecation] strtolower(): Passing null to parameter #1 ($string) of type string is deprecated at /var/www/default/htdocs/httpdocs/profiles/compuclient/modules/contrib/webform_civicrm/includes/utils.inc:404

This is now resolved by a NULL check.

This doesn't change the result
<img width="733" alt="Screenshot 2025-04-10 at 09 01 02" src="https://github.com/user-attachments/assets/34231a30-9fbe-4b92-b88e-8680f4485ee5" />
