### PR TITLE
CIVIMM-308: Remove Deprecated $dataArray Variable

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -262,11 +262,6 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
    * Send receipt
    */
   private function sendReceipt() {
-    // tax integration
-    if (!is_null($this->tax_rate)) {
-      $template = CRM_Core_Smarty::singleton();
-      $template->assign('dataArray', ["{$this->tax_rate}" => $this->tax_rate / 100]);
-    }
     if ($this->contributionIsIncomplete) {
       $template = CRM_Core_Smarty::singleton();
       $template->assign('is_pay_later', 1);


### PR DESCRIPTION
Overview
----------------------------------------
While sending the contribution receipt a variable by the name of **dataArray** was being assigned to the template but this variable has been obsolete and its not used anymore so this PR removes the code around this variable.

Previously each code that was sending these reciepts had to create and assign the dataArray variable but now its changed in civicrm core and it has been moved to one central place https://github.com/civicrm/civicrm-core/blob/master/CRM/Contribute/WorkflowMessage/ContributionTrait.php so now we dont need this code anymore here. It is explained in detail in this PR https://github.com/compucorp/compuclient/pull/643
