### PR TITLE
MM-213: Fix membership fee token value for multistep webform

### DIFF
--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -438,44 +438,177 @@ var wfCivi = (function ($, D) {
    */
   D.behaviors.membershipTypeFeesUpdate = {
     attach: function (context, settings) {
-      const membershipSelector = 'select[id*="membership-membership-type-id"]';
-      // Should apply for multiple membership type.
-      $(membershipSelector, context).each(function() {
-        // On change membership type field.
-        $(membershipSelector, context).once('feeAjax').change(function () {
-          const membershipSelect = $(this);
-          // Get name attribute of membership type.
-          var membershipSelectname = membershipSelect.attr('name');
-          // Pregmatch to fetch fieldset name.
-          // Capture fieldset name inside the first pair of square brackets.
-          var membershipSelectMatch = membershipSelectname.match(/\[([^\[\]]+)\]/);
-          // This is fieldset for each contact.
-          var civiContactFieldset = membershipSelectMatch[1];
+      const membershipSelector = '[id*="membership-membership-type-id"]';
 
-          const feeField = 'input[id*="membership-fee-amount-from-membership"]';
-          // Filter the fees input which has same fieldset as name.
-          const feeFieldInput = $(feeField).filter(function() {
-            // Safely checks if the name exists and includes the target.
-            return $(this).attr('name')?.includes(civiContactFieldset);
-          });
+      // Function to get membership value from Drupal settings.
+      function getMembershipValue(fieldsetName) {
+        // Solution 1: Check Drupal settings.
+        if (typeof Drupal.settings.webform !== 'undefined' &&
+            typeof Drupal.settings.webform.membershipValues !== 'undefined') {
+          return Drupal.settings.webform.membershipValues[fieldsetName] || '';
+        }
+        return '';
+      }
 
-          // Make ajax request when fees field present.
-          if (feeFieldInput) {
-            const membershipId = membershipSelect.val();
-            $.ajax({
-              url: '/webform-civicrm/js/getMembershipFees/' + membershipId,
-              dataType: 'json',
-              success: function (response) {
-                if (response.fees !== undefined) {
-                  $(feeFieldInput).val(response.fees);
-                }
-              },
-              error: function () {
-                console.log('Failed to fetch fee.');
-              }
-            });
+      // Function to update fee field with AJAX call.
+      function updateFeeField(membershipId, feeFieldInput) {
+        if (!membershipId || feeFieldInput.length === 0) {
+          return;
+        }
+
+        $.ajax({
+          url: '/webform-civicrm/js/getMembershipFees/' + membershipId,
+          dataType: 'json',
+          success: function (response) {
+            if (response.fees !== undefined) {
+              $(feeFieldInput).val(response.fees);
+            }
+          },
+          error: function () {
+            console.log('Failed to fetch fee.');
           }
         });
+      }
+
+      // Function to extract core membership pattern from field name.
+      function extractMembershipPattern(elementName) {
+        // Extract civicrm_X_membership_Y_membership from both structures:
+        // 1. submitted[civicrm_1_membership_1_membership_membership_type_id]
+        // 2. submitted[...][civicrm_1_membership_1_membership_membership_type_id]
+        const match = elementName.match(/(civicrm_\d+_membership_\d+_membership)_membership_type_id/);
+        return match ? match[1] : null;
+      }
+
+      // Function to find corresponding fee field.
+      function findCorrespondingFeeField(membershipPattern, context) {
+        // Look for fee field with the same pattern.
+        const feeFields = $('input[id*="membership-fee-amount-from-membership"]', context);
+        return feeFields.filter(function() {
+          const feeFieldName = $(this).attr('name');
+          if (!feeFieldName) {
+            return false;
+          }
+
+          // Check if this fee field contains the same membership pattern.
+          const feePattern = membershipPattern + '_fee_amount_from_membership';
+          return feeFieldName.includes(feePattern);
+        });
+      }
+
+      // Function to get current membership type value from the form.
+      function getCurrentMembershipValue(membershipPattern, context) {
+        const membershipFields = $(membershipSelector, context).filter(function() {
+          const fieldName = $(this).attr('name');
+          if (!fieldName) {
+            return false;
+          }
+
+          const fieldPattern = extractMembershipPattern(fieldName);
+          return fieldPattern === membershipPattern;
+        });
+
+        if (membershipFields.length === 0) {
+          return '';
+        }
+
+        const field = membershipFields.first();
+        if (field.is('input[type="radio"]')) {
+          const radioName = field.attr('name');
+          const checkedRadio = $('input[type="radio"][name="' + radioName + '"]:checked', context);
+          return checkedRadio.length > 0 ? checkedRadio.val() : '';
+        } else {
+          return field.val() || '';
+        }
+      }
+
+      // Handle each membership field individually.
+      $(membershipSelector, context).each(function() {
+        const $element = $(this);
+        const isRadio = $element.is('input[type="radio"]');
+        const isSelect = $element.is('select');
+
+        if (!isRadio && !isSelect) {
+          return;
+        }
+
+        const elementName = $element.attr('name');
+        const membershipPattern = extractMembershipPattern(elementName);
+
+        if (!membershipPattern) {
+          return;
+        }
+
+        // Set up change handler for this specific membership instance.
+        $element.once('feeAjax-' + membershipPattern).on('change', function () {
+          let selectedValue;
+
+          // Get selected value based on element type.
+          if (isRadio) {
+            const radioName = $(this).attr('name');
+            const checkedRadio = $('input[type="radio"][name="' + radioName + '"]:checked', context);
+            if (checkedRadio.length === 0) {
+              return;
+            }
+            selectedValue = checkedRadio.val();
+          } else {
+            selectedValue = $(this).val();
+          }
+
+          // Find the corresponding fee field.
+          const feeFieldInput = findCorrespondingFeeField(membershipPattern, context);
+          // Update fee field.
+          updateFeeField(selectedValue, feeFieldInput);
+        });
+
+        // Check for stored values on page load for this membership instance.
+        const storedValue = getMembershipValue(membershipPattern);
+        if (storedValue) {
+          // Find the corresponding fee field.
+          const feeFieldInput = findCorrespondingFeeField(membershipPattern, context);
+          // If fee field exists and is empty, update it.
+          if (feeFieldInput.length > 0) {
+            updateFeeField(storedValue, feeFieldInput);
+          }
+        }
+      });
+
+      // Also check for fee fields that might exist without corresponding membership fields on current step.
+      const feeFields = $('input[id*="membership-fee-amount-from-membership"]', context);
+      feeFields.each(function() {
+        const feeInput = $(this);
+        const feeInputName = feeInput.attr('name');
+
+        if (!feeInputName) {
+          return;
+        }
+
+        // Extract membership pattern from fee field name.
+        const match = feeInputName.match(/(civicrm_\d+_membership_\d+_membership)_fee_amount_from_membership/);
+        const membershipPattern = match ? match[1] : null;
+
+        if (!membershipPattern) {
+          return;
+        }
+
+        // Check if corresponding membership field exists on current step.
+        const correspondingMembershipField = $(membershipSelector).filter(function() {
+          const membershipFieldName = $(this).attr('name');
+          if (!membershipFieldName) {
+            return false;
+          }
+          const fieldPattern = extractMembershipPattern(membershipFieldName);
+          return fieldPattern === membershipPattern;
+        });
+
+        // Only process if no corresponding membership field exists on current step.
+        if (correspondingMembershipField.length === 0) {
+          // Check stored value from Drupal settings.
+          const membershipValue = getMembershipValue(membershipPattern);
+          // If we have a stored value and fee field is empty, update it.
+          if (membershipValue) {
+            updateFeeField(membershipValue, feeInput);
+          }
+        }
       });
     }
   };

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -95,6 +95,9 @@ function webform_civicrm_form_alter(&$form, &$form_state, $form_id) {
       wf_crm_admin_component::checkBillingPagination($form['#node']);
     }
   }
+
+  // Store membership value on every steps and pass
+  _webform_civicrm_form_alter_helper($form, $form_state, $form_id);
 }
 
 /**
@@ -1092,4 +1095,51 @@ function webform_civicrm_civicrm_alterPaymentProcessorParams($paymentObj, $rawPa
     $cookedParams['return'] = $rawParams['webform_redirect_success'];
     $cookedParams['cancel_return'] = $rawParams['webform_redirect_cancel'];
   }
+}
+
+/**
+ * Implements hook_form_alter().
+ */
+function _webform_civicrm_form_alter_helper(&$form, &$form_state, $form_id) {
+  // Early return if not a webform client form.
+  if (strpos($form_id, 'webform_client_form_') !== 0) {
+    return;
+  }
+
+  // Early return if no stored values from previous steps.
+  if (!isset($form_state['storage']['submitted'])) {
+    return;
+  }
+
+  $membership_values = [];
+
+  // Find membership type values in stored submissions.
+  foreach ($form_state['storage']['submitted'] as $cid => $value) {
+    $component = $form['#node']->webform['components'][$cid];
+
+    // Check if this is a membership type field.
+    if (strpos($component['form_key'], 'membership_membership_type_id') === FALSE) {
+      continue;
+    }
+
+    // Extract membership pattern from form_key.
+    // Form key: 'civicrm_X_membership_Y_membership_membership_type_id'.
+    // We want: 'civicrm_X_membership_Y_membership'.
+    if (preg_match('/(civicrm_\d+_membership_\d+_membership)_membership_type_id$/', $component['form_key'], $matches)) {
+      $membership_pattern = $matches[1];
+      $membership_values[$membership_pattern] = $value;
+    }
+  }
+
+  // Early return if no membership values found.
+  if (empty($membership_values)) {
+    return;
+  }
+
+  // Pass the values to JavaScript.
+  drupal_add_js([
+    'webform' => [
+      'membershipValues' => $membership_values,
+    ],
+  ], 'setting');
 }


### PR DESCRIPTION
PR continues to this older PR - https://github.com/compucorp/webform_civicrm/pull/78
## Overview
Added cross-step functionality for membership type and fee fields in multistep webforms. When users select a membership type on one step, the corresponding fee field is automatically populated on subsequent steps via AJAX, improving user experience and maintaining data consistency across the webform workflow.

## Before
- Membership fee fields were only populated when both membership type and fee fields existed on the same webform step
- Users had to manually navigate back to previous steps to see selected membership types when filling fee information
- Fee calculations failed in multistep webforms when fields were separated across different steps
- No persistence of membership selections across webform steps

## After
- Membership type selections are automatically passed from server-side form state to JavaScript via Drupal settings
- Fee fields are populated via AJAX regardless of which step they appear on
- System handles both simple and nested fieldset structures seamlessly
- Supports multiple contacts with multiple memberships per contact
- Works for both radio button and select list membership type fields
- Maintains exact pattern matching between membership instances and their corresponding fee fields

## Technical Details
**Core pattern matching system:**
- Extracts `civicrm_X_membership_Y_membership` patterns from field names
- Handles both structures: `submitted[field_name]` and `submitted[fieldset][field_name]`
- Uses regex pattern `/(civicrm_\d+_membership_\d+_membership)_membership_type_id/` for precise matching
- Added PHP helper function `_webform_civicrm_form_alter_helper()` to export previously selected membership values to `Drupal.settings` for JavaScript access
  ```php
  drupal_add_js([
    'webform' => [
      'membershipValues' => $membership_values,
    ],
  ], 'setting');
  ```

- Refactored JavaScript behavior to extract membership pattern matching logic into reusable functions for better maintainability
- Added `getMembershipValue()` function to retrieve stored membership values from Drupal settings for cross-step population
- Extended membership selector to support both select dropdowns and radio buttons by changing selector from `select[id*="..."]` to `[id*="..."]`
- Implemented `extractMembershipPattern()` function to extract the core membership identifier pattern (e.g., `civicrm_1_membership_1_membership`) from field names
- Added `findCorrespondingFeeField()` function to match fee fields with their corresponding membership fields using pattern matching
- Implemented automatic fee field population on page load when stored membership values exist from previous steps
- Added separate handler for orphaned fee fields (fee fields without corresponding membership field on current step) to check for and apply stored values

- Applied early return patterns in PHP code for improved readability and reduced nesting

**PHP implementation:**
```php
// Extract membership pattern from form_key.
    // Form key: 'civicrm_X_membership_Y_membership_membership_type_id'.
    // We want: 'civicrm_X_membership_Y_membership'.
    if (preg_match('/(civicrm_\d+_membership_\d+_membership)_membership_type_id$/', $component['form_key'], $matches)) {
      $membership_pattern = $matches[1];
      $membership_values[$membership_pattern] = $value;
    }
```

**JavaScript features:**
- Drupal behavior with proper `once()` binding to prevent duplicate handlers
- AJAX endpoint: `/webform-civicrm/js/getMembershipFees/{membershipId}`
- Handles orphaned fee fields (fee fields without corresponding membership fields on current step)
- Supports both radio buttons and select elements
- Console logging for debugging field matching and AJAX responses

## Comments
This change enables proper multi-step workflows where membership selection and fee calculation can be split across different pages, which is essential for complex multi-contact membership forms. The refactored JavaScript is more maintainable with separated concerns and reusable utility functions.