### PR TITLE
IRS-184: Stop calling the fees api if the fees field and membership id is not present to avoid multiple calls

### DIFF
--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -452,10 +452,12 @@ var wfCivi = (function ($, D) {
 
       // Function to update fee field with AJAX call.
       function updateFeeField(membershipId, feeFieldInput) {
-        if (!membershipId || feeFieldInput.length === 0) {
-          return;
+        if (!membershipId) {
+          throw new Error("Membership Id not found.");
         }
-
+        if ($(feeFieldInput).length === 0) {
+          throw new Error("Membership-fee-amount-from-membership not found.");
+        }
         $.ajax({
           url: '/webform-civicrm/js/getMembershipFees/' + membershipId,
           dataType: 'json',


### PR DESCRIPTION
## Overview
This PR fixes the issue of multiple MembershipApi calls when there no MembershipId present or No membership field is enabled.

This PR is not exact patch as the `webform_civicrm` module has been updated with new code, but we have added this fix in new code as well so core issues are also resolved.
**NOTE:** We have a new release for `webform_civicrm` module in core which has a bit of refactoring of the code and some changes. So in order to fix the core issue we have tested the latest released version of the `webform_civicrm` module on IRS we found that the same issue exists in new chanegs.
We have applied the fix according to new change done under the module, So that when we update the `webform_civicrm` module in next release it will take the fix and new changes along with it to all clients


## Before
[Membership application issue.webm](https://github.com/user-attachments/assets/700ccdec-d6a3-4aa8-84a8-bdb94fa0d142)


## After
[membership-form-solution.webm](https://github.com/user-attachments/assets/0b1b884e-355e-44fe-b44a-637b7af3ff34)


## Technical Details
1. Add condition for MembershipId and the fee field to check if they are present and have values then only proceed otherwise throw and error and stop Javascript flow.
2. We are throwing an exception so that we can track back any issues and clear indication is provided. It does not stop forms from submitting.

