### PR TITLE
COMCL-1354: Fix Contribution Rounding Issue

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1944,11 +1944,8 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $salesTaxFirstAmount = wf_crm_aval($contributionParams, 'tax_amount', NULL, TRUE);
     $nondeductibleFirstAmount = wf_crm_aval($contributionParams, 'non_deductible_amount', NULL, TRUE);
     if ($numInstallments > 0) {
-      // DRU-2862396 - we must ensure to only present 2 decimals to CiviCRM:
-      $contributionRecurAmount = round(($contributionParams['total_amount'] / $numInstallments), 2, PHP_ROUND_HALF_UP);
-      $contributionFirstAmount = $contributionRecurAmount;
-      $salesTaxFirstAmount = round(($salesTaxFirstAmount / $numInstallments), 2, PHP_ROUND_HALF_UP);
-      $nondeductibleFirstAmount = round(($nondeductibleFirstAmount / $numInstallments), 2, PHP_ROUND_HALF_UP);
+      $contributionRecurAmount = 0;
+      $salesTaxFirstAmount = 0;
 
       // Calculate the line_items for the first contribution:
       // At this point line_items are set to the full (non-installment) amounts.
@@ -1956,7 +1953,13 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         $this->line_items[$key]['unit_price'] = round(($k['unit_price'] / $numInstallments), 2, PHP_ROUND_HALF_UP);
         $this->line_items[$key]['line_total'] = round(($k['line_total'] / $numInstallments), 2, PHP_ROUND_HALF_UP);
         $this->line_items[$key]['tax_amount'] = round(($k['tax_amount'] / $numInstallments), 2, PHP_ROUND_HALF_UP);
+
+        $contributionRecurAmount += $this->line_items[$key]['line_total'] + $this->line_items[$key]['tax_amount'];
+        $salesTaxFirstAmount += $this->line_items[$key]['tax_amount'];
       }
+
+      $contributionFirstAmount = $contributionRecurAmount;
+      $nondeductibleFirstAmount = $contributionRecurAmount;
     }
 
     // Create Params for Creating the Recurring Contribution Series and Create it


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes an issue due to which the installment contributions amount was not being calculated correctly and they had discrepancy between line item totals and contribution totals by one cent.

## Technical Details
Previously we were recalculating the contribution totals by dividing the amounts by number of installments and then roun ding it up which created a one cent difference with line item amounts. This PR fixes the issue by calculating contribution amounts through line items.

## Example
Lets assume a fixed membership signup with a 100 pounds fee and vat of 20% which makes the total amount equals to 120 and if we signup with a membership start date of 15 Jan then the correct pro rated amount is 115.39 and the created first eleven installments should be of 9.61 and the last one should be of 9.68 but previously what we had was eleven installments created with amount of 9.62 and last one with 9.69