### PR TITLE
CIVIPLMMSR-640: Fix File Upload

### DIFF
--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -752,14 +752,12 @@ abstract class wf_crm_webform_base {
       $file_uri = CRM_Utils_File::makeFileName($file->filename ?? '');
       $path = file_unmanaged_copy($file->uri, $config->customFileUploadDir . $file_uri);
       if ($path) {
-        $result = civicrm_api4('File', 'create', [
-          'values' => [
-            'uri' => $file_uri,
-            'mime_type' => $file->filemime,
-          ],
-          'checkPermissions' => FALSE,
+        $fileDAO = CRM_Core_BAO_File::create([
+          'uri' => $file_uri,
+          'mime_type' => $file->filemime,
         ]);
-        return wf_crm_aval($result->first(), 'id');
+
+        return $fileDAO->id;
       }
     }
     return NULL;


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes an issue which was not letting users to upload files to a civicrm field through webform.

Before
----------------------------------------
When user tried to upload the file to a civicrm field user was presented an error and file upload failed.

After
----------------------------------------
User is able to submit the file upload to any exposed civicrm field.

Technical Details
----------------------------------------
This issue was raised due to fact that recent security update does not allow setting the file uri while using the API4, so instead of using API$ this PR changes the usage to Bao for file creation.