### PR TITLE
ASESPRT-890: Only return the id when looking up an existing activity

### DIFF
--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -789,6 +789,12 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
                 'status_id' => ['IN' => (array)$this->data['activity'][$n]['existing_activity_status']],
                 'is_deleted' => '0',
                 'is_current_revision' => '1',
+                // Only the id is used below. Without an explicit
+                // return the api selects every column plus every
+                // activity custom field, so it reads the off-page
+                // details TEXT and LEFT JOINs every custom group
+                // table. On a large civicrm_activity that is minutes.
+                'return' => ['id'],
                 'options' => ['limit' => 1],
               ];
               $params['activity_type_id'] = $this->data['activity'][$n]['activity'][1]['activity_type_id'];


### PR DESCRIPTION
Overview
----------------------------------------
On sites with a large activity table, any page carrying a webform that has **"existing activity status"** configured takes minutes to load for logged-in visitors. On ASE this was 60–120 seconds on four public pages (`/`, `/news`, `/ase-journals`, `/ase-resource-hub`). Anonymous visitors are unaffected.

The lookup that finds a contact's existing activity was asking CiviCRM for the whole activity record when it only ever uses the record's id. This PR asks for just the id.

This affects more than one site: both Compuclient lines (7.x-4.x on CiviCRM 5.75 and 7.x-7.x on CiviCRM 6.4.1) pin this branch, so any site with a form using "existing activity status" and a sizeable `civicrm_activity` has the same latent problem. ASE simply had the table size to make it visible.

Jira: ASESPRT-890

D7 or D8?
----------------------------------------
This is **D7WFC**. I have not raised a D8WFC PR.

The same pattern appears in upstream `colemanw/webform_civicrm` `7.x-4.x`, which still has no `return` key on this call, so this is a genuine divergence rather than a re-implementation of something already fixed. The 6.x branches likely carry the same defect, but I have not verified that and would rather someone who works on D8WFC confirm before a PR is raised there.

Before
----------------------------------------
`findExistingActivities()` called `Activity.get` with no `return` parameter. CiviCRM's `SelectQuery::buildSelectFields()` treats an empty select as "return everything":

```php
$return_all_fields = (empty($this->select) || !is_array($this->select));
$return = $return_all_fields ? $this->entityFieldNames : $this->select;
if ($return_all_fields || in_array('custom', $this->select)) {
  foreach (array_keys($this->apiFieldSpec) as $fieldName) {
    if (strpos($fieldName, 'custom_') === 0) { $return[] = $fieldName; }
```

So the query selected:

- every column of `civicrm_activity`, including the `details` TEXT column;
- **plus every activity custom field** — `_civicrm_api3_basic_get()` populates `apiFieldSpec` with all custom fields for the entity regardless of activity subtype, and each one adds an uncapped `LEFT JOIN` to its custom-group table. On ASE that meant a *Newsletter Sign Up* lookup joining the *CPD Audit* custom table, which is what first gave the mechanism away.

**Measured impact on ASE production.** `civicrm_activity` is 663,826 rows / 1.6 GB, of which the `details` column alone is 985 MB, against a 1.45 GB InnoDB buffer pool — so the scan cannot stay cached.

```
SELECT a.*  ...  106,136 ms
```

New Relic recorded the resulting page transactions at an average of **72.8 s** and a maximum of **151 s**, against sub-2s for every comparable authenticated page on the site (`/user/*/home` 1.05 s, `/Events` 0.92 s, `/civicrm` 2.04 s).

Because the lookup only runs once a contact resolves, the split is stark — anonymous p50 across the four pages is ~0.6 s and site-wide p95 is 1.4 s, while logged-in requests sit at 60–120 s. Site-wide *average* exceeding p95 was the tell.

This is long-standing, not a recent regression: New Relic's 8-day history shows the homepage at 128.95 s on 02/08 and 139.42 s on 03/08, with 12 requests over 20 s in the eight days before the release that surfaced it.

After
----------------------------------------
```
SELECT a.id ...     495 ms
```

A 214× reduction, from the projection alone. Worst case — a contact with no matching activity, so the scan runs to completion — measured **4 ms**.

Technical Details
----------------------------------------
The change is one array key. `findExistingActivities()` consumes nothing but `$items[0]['id']`, and `$this->ent['activity'][$n]` is only ever written as `['id' => …]` (preprocess) and only ever read as `['id']` (`wf_crm_webform_postprocess.inc`, create-vs-update branch and `$params['id']`).

**The query plan is unchanged** — this is a projection fix, not an access-path fix:

Before (`SELECT a.*`):
```
table  type   key                  rows     Extra
a      ALL    NULL                 663,826  Using where
ac     eq_ref UI_activity_contact  1        Using index
```

After (`SELECT a.id`):
```
table  type   key                  rows     Extra
a      ALL    NULL                 663,826  Using where
ac     eq_ref UI_activity_contact  1        Using index
```

Identical on both rows, including the semi-join. The saving is entirely the off-page `details` reads and the dropped custom-group joins.

That matters for review beyond performance: because the driving access path stays a PK-ordered clustered-index scan, the **same first matching row** is returned. The custom-group tables were nested-loop appendages hanging off `a.id` and could never reorder the driving scan — so this is behaviour-preserving for a structural reason, not merely an observed one.

**Parameter plumbing.** `return` survives the wrappers: `wf_crm_apivalues()` does `$params += ['options' => []]` then `$params['options'] += ['limit' => 0]`, and `wf_civicrm_api()` does `$params += ['check_permissions' => FALSE, 'version' => 3]`. `+=` never overwrites an existing key, so both the explicit `limit => 1` and the new `return` reach `civicrm_api3` intact. (One latent trap for future readers: if anyone adds the optional 4th `$value` argument to this call, `+=` keeps `['id']` and the extraction loop would return NULLs. Not an issue today.)

**Secondary correctness benefit.** Pre-patch, a *multi-record* activity custom group produced duplicate rows for a single activity, which `SelectQuery::run()` silently collapses by id. That made `count` and any `limit > 1` quietly wrong on sites that have such a group — invisible at `limit 1`, which is why it went unnoticed. Restricting the return removes that class of defect entirely, so this is strictly better than the status quo rather than merely equivalent.

Testing
----------------------------------------
All verification was read-only. The patch was **not** deployed to any environment; instead the API was invoked with and without the `return` parameter, which is precisely what the change alters.

**1. Functional equivalence, both CiviCRM versions.** One module branch serves Compuclient 7.x-4.x (CiviCRM 5.75) and 7.x-7.x (CiviCRM 6.4.1), so both were exercised — 5.75 on ASE staging, 6.4.1 on an internal cc-test site. The exact parameter set from `findExistingActivities()` was used (`sequential`, `target_contact_id`, `status_id => ['IN' => …]`, `is_deleted`, `is_current_revision`, `activity_type_id`, `options.limit`):

| check | 5.75 | 6.4.1 |
|---|---|---|
| same ids returned, limit 1 | yes | yes |
| same ids returned, limit 5 | yes (`14,15,16,17,18`) | yes (`1,4,5`) |
| sequential list preserved | yes | yes |
| `values[0]['id']` accessible | yes | yes |
| empty-result shape (no match) | identical | identical |
| fields returned | 17 → 4 | 16 → 4 |

**2. The `details` column is genuinely dropped.** Against a staging activity carrying a 20 KB `details` value:

| | fields | `details` | bytes transferred | payload |
|---|---|---|---|---|
| without `return` | 17 | present | 20,245 | 24,623 bytes |
| with `return => ['id']` | 4 | absent | **0** | **197 bytes** |

**3. Version parity of the CiviCRM code path.** `civicrm_api3_activity_get`, `_civicrm_api3_get_options_from_params` and `buildSelectFields` were diffed between 5.75 and 6.4.1. The only differences are PHP 8 cosmetics (`strpos(…) === 0` → `str_starts_with(…)`), so the mechanism is identical on both.

**4. Query plans and timings** were taken on ASE production against the live `civicrm_activity` (figures above).

**5. Independent review.** The change was reviewed independently before raising. That review is where the multi-record custom-group finding above came from, and it corrected two things in my original reasoning — the equivalence test on small datasets proves less than the production EXPLAIN does, and the real risk of adding an `ORDER BY` would be losing the scan's early exit rather than sort cost. An `ORDER BY id ASC` variant was measured for completeness: no filesort, 485 ms vs 469 ms, plan resolves to a `PRIMARY` index scan.

**Not verified**, in the interest of being straight about it:

- No end-to-end page render with the patch deployed. Every link between the webform code and the API is read or runtime-verified, but nobody has watched a real page get fast. Neither test environment has the data volume to show it.
- The custom-group `LEFT JOIN` removal is code-verified but not runtime-demonstrated — neither test site has an activity carrying custom data. It is the secondary effect; `details` is the measured cost driver.

Comments
----------------------------------------
Two things deliberately **not** in this PR:

1. **The unordered `LIMIT 1`.** This call has no sort, so on a PK-ordered scan it updates the contact's *oldest* matching activity rather than their most recent. On ASE, 95 of 1,425 contacts with a Newsletter Sign Up activity have more than one, so this is observable. It is pre-existing and unaffected by this change, and picking a winner is a product decision — if it is changed it should be `activity_date_time DESC, id DESC` (not `id DESC`, which breaks on imported or backdated activities) and would likely need a supporting index. Raised separately.

2. **An index on `civicrm_activity`.** The full scan remains. It is now cheap enough not to matter here, and adding schema across every site to work around a query shape was the worse trade. A composite index was measured as an alternative and rejected on that basis, not on performance.

No screenshots — the change has no visible UI.
